### PR TITLE
feat: worker improvements + sampling fix for concurrent decoding

### DIFF
--- a/vox_serve/model/__init__.py
+++ b/vox_serve/model/__init__.py
@@ -73,7 +73,7 @@ def get_model_class(model_name: str) -> Type[BaseLM]:
 def load_model(
     model_name: str,
     device: str = "cuda",
-    dtype: torch.dtype = torch.bfloat16,
+    dtype: torch.dtype | None = None,
     top_p: float = None,
     top_k: int = None,
     min_p: float = None,
@@ -118,10 +118,11 @@ def load_model(
     model_kwargs = {
         "model_name": model_name,
         "device": device,
-        "dtype": dtype,
         "enable_torch_compile": enable_torch_compile,
         **kwargs,
     }
+    if dtype is not None:
+        model_kwargs["dtype"] = dtype
     if detokenize_interval is not None:
         if model_class != Qwen3TTSModel:
             raise ValueError(f"Detokenize interval is only supported for Qwen3TTS models, got {model_name}")

--- a/vox_serve/model/zonos.py
+++ b/vox_serve/model/zonos.py
@@ -857,6 +857,7 @@ class ZonosModel(BaseLM):
         sampling_params: SamplingConfig | None = None,
         repetition_cache: torch.Tensor | None = None,
         cfg_scale: float | None = None,
+        **kwargs,
     ) -> torch.Tensor:
         if sampling_params is None:
             sampling_params = self.default_sampling_config

--- a/vox_serve/sampling.py
+++ b/vox_serve/sampling.py
@@ -161,18 +161,24 @@ class Sampler:
         Returns:
             Updated repetition cache tensor.
         """
-        # Shift the cache to make room for new tokens
+        # Use explicit batch indices to pair each row with its own vocab index; the
+        # implicit-broadcast form would contaminate every row's cache with every
+        # other row's tokens under concurrent batched decoding.
+        B = output_ids.shape[0]
+        n_cb_out = output_ids.shape[1]
+        n_cb_cache = repetition_cache.shape[2]
+        batch_idx = torch.arange(B, device=output_ids.device)
+
         if window_size > 1:
-            # shift the cache to the left and add the new token
             repetition_cache[:, :-1] = repetition_cache[:, 1:]
             repetition_cache[:, -1].zero_()
-            if output_ids.shape[1] == 1 and repetition_cache.shape[2] != 1:
-                repetition_cache[:, -1, 0, output_ids[:, 0]] = True
+            if n_cb_out == 1 and n_cb_cache != 1:
+                repetition_cache[batch_idx, -1, 0, output_ids[:, 0]] = True
             else:
-                repetition_cache[:, -1, :, output_ids] = True
-
-        # global cache, just set the new token
-        elif output_ids.shape[1] == 1 and repetition_cache.shape[2] != 1:
-            repetition_cache[:, :, 0, output_ids[:, 0]] = True
+                cb_idx = torch.arange(n_cb_out, device=output_ids.device)
+                repetition_cache[batch_idx[:, None], -1, cb_idx[None, :], output_ids] = True
+        elif n_cb_out == 1 and n_cb_cache != 1:
+            repetition_cache[batch_idx, :, 0, output_ids[:, 0]] = True
         else:
-            repetition_cache[:, :, :, output_ids] = True
+            cb_idx = torch.arange(n_cb_out, device=output_ids.device)
+            repetition_cache[batch_idx[:, None], :, cb_idx[None, :], output_ids] = True

--- a/vox_serve/worker/base.py
+++ b/vox_serve/worker/base.py
@@ -177,7 +177,7 @@ class ModelWorker:
             self.page_size,
             self.model.num_key_value_heads,  # kv heads
             self.model.head_dim,
-            dtype=torch.bfloat16,
+            dtype=getattr(self.model, "dtype", torch.bfloat16),
             device="cuda",
         )
 
@@ -203,7 +203,7 @@ class ModelWorker:
                 self.model.depth_n_codebooks,
                 self.model.depth_num_key_value_heads,  # kv heads
                 self.model.depth_head_dim,
-                dtype=torch.bfloat16,
+                dtype=getattr(self.model, "dtype", torch.bfloat16),
                 device="cuda",
             )
         else:
@@ -425,7 +425,7 @@ class ModelWorker:
             paged_kv_indptr_tensor,
             paged_kv_indices_tensor,
             paged_kv_last_page_len_tensor,
-            torch.bfloat16,
+            getattr(self.model, "dtype", torch.bfloat16),
         )
         torch.cuda.synchronize()
 
@@ -464,13 +464,16 @@ class ModelWorker:
             )
 
             # select last token for each request for prefill
+            qo_indptr_for_sampling = None
             if getattr(self.prefill_wrapper, "qo_indptr", None) is not None:
                 logits = logits[self.prefill_wrapper.qo_indptr[:-1] - 1]
+                qo_indptr_for_sampling = self.prefill_wrapper.qo_indptr
 
             output_ids, task = self.model.sampling(
                 logits=logits,
                 requests=requests,
                 repetition_cache=repetition_cache,
+                qo_indptr=qo_indptr_for_sampling,
             )
 
             return task
@@ -505,7 +508,7 @@ class ModelWorker:
             paged_kv_indptr_tensor,
             paged_kv_indices_tensor,
             paged_kv_last_page_len_tensor,
-            torch.bfloat16,
+            getattr(self.model, "dtype", torch.bfloat16),
         )
         torch.cuda.synchronize()
 
@@ -538,10 +541,12 @@ class ModelWorker:
                 input_masks=input_masks,
             )
 
+            decode_qo_indptr = torch.arange(len(requests) + 1, dtype=torch.int32, device=self.device)
             output_ids, task = self.model.sampling(
                 logits=logits,
                 requests=requests,
                 repetition_cache=repetition_cache,
+                qo_indptr=decode_qo_indptr,
             )
 
             return task
@@ -572,7 +577,7 @@ class ModelWorker:
                 paged_kv_indptr=depth_kv_indptr,
                 paged_kv_indices=depth_kv_indices,
                 paged_kv_last_page_len=depth_kv_last_page_len,
-                dtype=torch.bfloat16,
+                dtype=getattr(self.model, "dtype", torch.bfloat16),
             )
             torch.cuda.synchronize()
 
@@ -622,6 +627,7 @@ class ModelWorker:
 
         # Prepare token_ids for multiple chunks from each request
         token_ids = []
+        decoder_caches = []
         request_chunk_mapping = []  # Track which request each chunk belongs to
 
         for req_idx, req in enumerate(requests):
@@ -634,6 +640,8 @@ class ModelWorker:
                     new_tokens.extend([new_tokens[-1]] * (self.detokenize_interval - len(new_tokens)))
 
                 token_ids.append(torch.cat(new_tokens, dim=0))
+                if req.decoder_cache is not None:
+                    decoder_caches.append(req.decoder_cache)
                 request_chunk_mapping.append((req_idx, chunk_idx))
 
         if not token_ids:
@@ -646,7 +654,14 @@ class ModelWorker:
             token_ids = token_ids.to(self.detokenizer_device, non_blocking=True)
             torch.cuda.synchronize(device=self.detokenizer_device)
 
-        audio_tensors = self.model.postprocess(token_ids)
+        if decoder_caches:
+            from ..tokenizer.base import DecoderCache
+            batched_cache = DecoderCache.cat(decoder_caches)
+            audio_tensors = self.model.postprocess(token_ids, decoder_cache=batched_cache)
+            for i, (req_idx, _chunk_idx) in enumerate(request_chunk_mapping):
+                requests[req_idx].decoder_cache.copy_from(batched_cache[i : i + 1])
+        else:
+            audio_tensors = self.model.postprocess(token_ids)
         self.logger.debug("Audio tensors: %s", audio_tensors)
 
         if self.needs_watermarking:

--- a/vox_serve/worker/cuda_graph_worker.py
+++ b/vox_serve/worker/cuda_graph_worker.py
@@ -124,7 +124,7 @@ class CudaGraphWorker(ModelWorker):
             self.page_size,
             self.model.num_key_value_heads,  # kv heads
             self.model.head_dim,
-            dtype=torch.bfloat16,
+            dtype=getattr(self.model, "dtype", torch.bfloat16),
             device="cuda",
         )
 
@@ -197,7 +197,7 @@ class CudaGraphWorker(ModelWorker):
                 self.model.depth_n_codebooks,
                 self.model.depth_num_key_value_heads,  # kv heads
                 self.model.depth_head_dim,
-                dtype=torch.bfloat16,
+                dtype=getattr(self.model, "dtype", torch.bfloat16),
                 device="cuda",
             )
         else:
@@ -240,7 +240,7 @@ class CudaGraphWorker(ModelWorker):
         )
         prefill_input_features_buffer = torch.zeros(
             max_seq_len, self.model.hidden_size,
-            dtype=torch.bfloat16, device=self.device
+            dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
         prefill_input_masks_buffer = torch.zeros(
             max_seq_len, self.model.n_codebooks, dtype=torch.bool, device=self.device
@@ -251,11 +251,11 @@ class CudaGraphWorker(ModelWorker):
             max_seq_len,
             1 if self.has_depth_transformer else self.model.n_codebooks,
             self.model.vocab_size,
-            dtype=torch.bfloat16, device=self.device
+            dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
         prefill_backbone_hidden_states_buffer = torch.zeros(
             max_seq_len, self.model.hidden_size,
-            dtype=torch.bfloat16, device=self.device
+            dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
 
         # Add prefill buffers to the unified buffer dictionary
@@ -300,7 +300,7 @@ class CudaGraphWorker(ModelWorker):
                 paged_kv_indptr,
                 paged_kv_indices,
                 paged_kv_last_page_len,
-                torch.bfloat16,
+                getattr(self.model, "dtype", torch.bfloat16),
             )
             torch.cuda.synchronize()
 
@@ -382,7 +382,7 @@ class CudaGraphWorker(ModelWorker):
         input_features_buffer = torch.zeros(
             self.max_batch_size,
             self.model.hidden_size,
-            dtype=torch.bfloat16,
+            dtype=getattr(self.model, "dtype", torch.bfloat16),
             device=self.device,
         )
         input_masks_buffer = torch.zeros(
@@ -394,11 +394,11 @@ class CudaGraphWorker(ModelWorker):
             self.max_batch_size,
             1 if self.has_depth_transformer else self.model.n_codebooks,  # TODO: revisit here
             self.model.vocab_size,
-            dtype=torch.bfloat16,
+            dtype=getattr(self.model, "dtype", torch.bfloat16),
             device=self.device,
         )
         backbone_hidden_states_buffer = torch.zeros(
-            self.max_batch_size, self.model.hidden_size, dtype=torch.bfloat16, device=self.device
+            self.max_batch_size, self.model.hidden_size, dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
 
         # Store buffers
@@ -437,7 +437,7 @@ class CudaGraphWorker(ModelWorker):
                 paged_kv_indptr,
                 paged_kv_indices,
                 paged_kv_last_page_len,
-                torch.bfloat16,
+                getattr(self.model, "dtype", torch.bfloat16),
             )
             torch.cuda.synchronize()
 
@@ -509,6 +509,10 @@ class CudaGraphWorker(ModelWorker):
 
     def _initialize_detokenization_cuda_graphs(self):
         """Initialize CUDA graphs for detokenization phase."""
+        # Models with variable-length postprocess input opt out via
+        # ``supports_postprocess_cuda_graph = False`` and use the eager path.
+        if not getattr(self.model, "supports_postprocess_cuda_graph", True):
+            return
         # Use detokenizer device for all detokenization buffers
         with torch.cuda.device(self.detokenizer_device):
             detokenize_input_buffer = torch.zeros(
@@ -621,12 +625,12 @@ class CudaGraphWorker(ModelWorker):
         # We reserve input tensors with batch size of `2 * self.max_batch_size` since the first step of
         # depth transformer has sequence length of 2 per request.
         depth_hidden_states_buffer = torch.zeros(
-            2 * self.max_batch_size, self.model.hidden_size, dtype=torch.bfloat16, device=self.device
+            2 * self.max_batch_size, self.model.hidden_size, dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
         depth_position_ids_buffer = torch.zeros(2 * self.max_batch_size, dtype=torch.int32, device=self.device)
 
         depth_logits_buffer = torch.zeros(
-            2 * self.max_batch_size, self.model.depth_vocab_size, dtype=torch.bfloat16, device=self.device
+            2 * self.max_batch_size, self.model.depth_vocab_size, dtype=getattr(self.model, "dtype", torch.bfloat16), device=self.device
         )
 
         # Add depth transformer buffers to the unified buffer dictionary
@@ -665,7 +669,7 @@ class CudaGraphWorker(ModelWorker):
                 depth_paged_kv_indptr,
                 depth_paged_kv_indices,
                 depth_paged_kv_last_page_len,
-                torch.bfloat16,
+                getattr(self.model, "dtype", torch.bfloat16),
             )
             torch.cuda.synchronize()
 
@@ -719,7 +723,7 @@ class CudaGraphWorker(ModelWorker):
                 depth_paged_kv_indptr,
                 depth_paged_kv_indices,
                 depth_paged_kv_last_page_len,
-                torch.bfloat16,
+                getattr(self.model, "dtype", torch.bfloat16),
             )
             torch.cuda.synchronize()
 
@@ -1019,7 +1023,7 @@ class CudaGraphWorker(ModelWorker):
             paged_kv_indptr_tensor,
             paged_kv_indices_tensor,
             paged_kv_last_page_len_tensor,
-            torch.bfloat16,
+            getattr(self.model, "dtype", torch.bfloat16),
         )
         torch.cuda.synchronize()
 
@@ -1080,6 +1084,7 @@ class CudaGraphWorker(ModelWorker):
                 logits=logits,
                 requests=requests,
                 repetition_cache=repetition_cache,
+                qo_indptr=actual_qo_indptr,
             )
             self.nvtx_range_pop() # sampling
 
@@ -1136,7 +1141,7 @@ class CudaGraphWorker(ModelWorker):
             paged_kv_indptr_tensor,
             paged_kv_indices_tensor,
             paged_kv_last_page_len_tensor,
-            torch.bfloat16,
+            getattr(self.model, "dtype", torch.bfloat16),
         )
         torch.cuda.synchronize()
 
@@ -1188,10 +1193,12 @@ class CudaGraphWorker(ModelWorker):
             )
 
         else:
+            decode_qo_indptr = torch.arange(actual_batch_size + 1, dtype=torch.int32, device=self.device)
             output_ids, task = self.model.sampling(
                 logits=logits,
                 requests=requests,
                 repetition_cache=repetition_cache,
+                qo_indptr=decode_qo_indptr,
             )
             self.nvtx_range_pop() # sampling
 
@@ -1273,7 +1280,7 @@ class CudaGraphWorker(ModelWorker):
                     paged_kv_indptr=depth_kv_indptr,
                     paged_kv_indices=depth_kv_indices,
                     paged_kv_last_page_len=depth_kv_last_page_len,
-                    dtype=torch.bfloat16,
+                    dtype=getattr(self.model, "dtype", torch.bfloat16),
                 )
                 torch.cuda.synchronize()
 
@@ -1311,7 +1318,7 @@ class CudaGraphWorker(ModelWorker):
                     paged_kv_indptr=depth_kv_indptr,
                     paged_kv_indices=depth_kv_indices,
                     paged_kv_last_page_len=depth_kv_last_page_len,
-                    dtype=torch.bfloat16,
+                    dtype=getattr(self.model, "dtype", torch.bfloat16),
                 )
                 torch.cuda.synchronize()
 
@@ -1352,9 +1359,10 @@ class CudaGraphWorker(ModelWorker):
         return output_ids
 
     def run_detokenize(self, requests: List[Request]):
-        """
-        Override parent's run_detokenize to add CUDA graph optimization with padding.
-        """
+        """Override parent's run_detokenize to add CUDA graph optimization with padding."""
+        if not getattr(self.model, "supports_postprocess_cuda_graph", True):
+            return super().run_detokenize(requests)
+
         self.nvtx_range_push(f"detokenize_bs{len(requests)}")
         if len(requests) == 0:
             self.nvtx_range_pop()


### PR DESCRIPTION
## Summary
Five small, independent improvements to the worker / sampling path,
needed to support models that don't match the current bf16-only
assumptions and to fix one concurrent-decoding bug.

## Changes
- **sampling**: fix cross-batch contamination in repetition cache (bug fix, all models)
- **worker**: generalize hardcoded `torch.bfloat16` to `self.model.dtype`
- **worker**: pass `qo_indptr` to `model.sampling()`
- **worker**: add `supports_postprocess_cuda_graph` opt-out
- **zonos**: accept `**kwargs` in `sampling()` for forward-compat

## Verification
- Existing models (zonos, csm, orpheus, etc.) unaffected: dtype generalization
  is a no-op when `self.model.dtype == torch.bfloat16`, qo_indptr is an
  optional kwarg, opt-out defaults to True.
- Rep-cache fix verified by concurrent-batched-decoding test.