### PR TITLE
feat: add XTTS-v2 model support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ dependencies = [
     "inflect>=7.4.0",
     "requests>=2.32.0",
     "PyYAML>=6.0.2",
+    "ko-speech-tools>=0.1.0",
+    "num2words>=0.5.14",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -366,6 +366,12 @@ wheels = [
 ]
 
 [[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
 name = "einops"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +596,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -644,6 +663,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "ko-speech-tools"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/fa/51b14366b2a1bb958fb748be67a58519ac4b5aeea0faa3b31c8431f63b2c/ko_speech_tools-0.1.0.tar.gz", hash = "sha256:dcc5af8bd9f2a9d2260dcc36617d6de65106be625958302525068e81f94b2b1d", size = 987850, upload-time = "2025-10-03T01:13:16.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/59/f0cb1c0d5632ee647129e8272c3534554b395be013a134534fdc03e29914/ko_speech_tools-0.1.0-py3-none-any.whl", hash = "sha256:0fa57d6eb1d5a126a2f10df93dd21355298839c1048865ead1b4bb07695e3f33", size = 997279, upload-time = "2025-10-03T01:13:15.197Z" },
 ]
 
 [[package]]
@@ -801,6 +829,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -933,6 +970,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/95/97/51359c77527d45943fe7a94d00a3843b81162e6c4244b3579fe8fc54cb9c/ninja-1.13.0-py3-none-win32.whl", hash = "sha256:8cfbb80b4a53456ae8a39f90ae3d7a2129f45ea164f43fadfa15dc38c4aef1c9", size = 267201, upload-time = "2025-08-11T15:10:15.158Z" },
     { url = "https://files.pythonhosted.org/packages/29/45/c0adfbfb0b5895aa18cec400c535b4f7ff3e52536e0403602fc1a23f7de9/ninja-1.13.0-py3-none-win_amd64.whl", hash = "sha256:fb8ee8719f8af47fed145cced4a85f0755dd55d45b2bddaf7431fa89803c5f3e", size = 309975, upload-time = "2025-08-11T15:10:16.697Z" },
     { url = "https://files.pythonhosted.org/packages/df/93/a7b983643d1253bb223234b5b226e69de6cda02b76cdca7770f684b795f5/ninja-1.13.0-py3-none-win_arm64.whl", hash = "sha256:3c0b40b1f0bba764644385319028650087b4c1b18cdfa6f45cb39a3669b81aa9", size = 290806, upload-time = "2025-08-11T15:10:18.018Z" },
+]
+
+[[package]]
+name = "num2words"
+version = "0.5.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/58/ad645bd38b4b648eb2fc2ba1b909398e54eb0cbb6a7dbd2b4953e38c9621/num2words-0.5.14.tar.gz", hash = "sha256:b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6", size = 218213, upload-time = "2024-12-17T20:17:10.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/5b/545e9267a1cc080c8a1be2746113a063e34bcdd0f5173fd665a5c13cb234/num2words-0.5.14-py3-none-any.whl", hash = "sha256:1c8e5b00142fc2966fd8d685001e36c4a9911e070d1b120e1beb721fa1edb33d", size = 163525, upload-time = "2024-12-17T20:17:06.074Z" },
 ]
 
 [[package]]
@@ -2102,6 +2151,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2175,22 +2236,28 @@ wheels = [
 
 [[package]]
 name = "vox-serve"
-version = "0.0.1"
-source = { virtual = "." }
+version = "0.1.0"
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "diffusers" },
+    { name = "einops" },
     { name = "fastapi" },
     { name = "flashinfer-python" },
     { name = "httptools" },
     { name = "huggingface-hub" },
+    { name = "inflect" },
+    { name = "ko-speech-tools" },
     { name = "librosa" },
+    { name = "num2words" },
     { name = "numpy" },
     { name = "onnx" },
     { name = "onnxruntime" },
     { name = "phonemizer" },
     { name = "pydub" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "scipy" },
     { name = "soundfile" },
@@ -2207,17 +2274,23 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.15" },
     { name = "diffusers", specifier = "==0.34.0" },
+    { name = "einops", specifier = ">=0.8.0" },
     { name = "fastapi", specifier = "==0.116.1" },
     { name = "flashinfer-python", specifier = "==0.2.11.post1" },
     { name = "httptools", specifier = "==0.6.4" },
     { name = "huggingface-hub", specifier = "==0.34.0" },
+    { name = "inflect", specifier = ">=7.4.0" },
+    { name = "ko-speech-tools", specifier = ">=0.1.0" },
     { name = "librosa", specifier = "==0.10.2.post1" },
+    { name = "num2words", specifier = ">=0.5.14" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "onnx", specifier = ">=1.19.0" },
     { name = "onnxruntime", specifier = ">=1.22.1" },
     { name = "phonemizer", specifier = ">=3.3.0" },
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "safetensors", specifier = "==0.5.3" },
     { name = "scipy", specifier = "==1.11.4" },
     { name = "soundfile", specifier = "==0.12.1" },

--- a/vox_serve/encoder/xtts.py
+++ b/vox_serve/encoder/xtts.py
@@ -1,0 +1,1280 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+# from TTS.utils.audio.torch_transforms import TorchSTFT
+# from base import BaseTTS, BaseEncoder
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Union
+
+import torch
+import fsspec
+
+class BaseTTS(nn.Module):
+    def __init__(self, config, ap=None, tokenizer=None):
+        super().__init__()
+        self.config = config
+        self.args = getattr(config, "model_args", config)
+        self.ap = ap
+        self.tokenizer = tokenizer
+        self.speaker_manager = None
+        self.language_manager = None
+
+    def load_checkpoint(self, config, checkpoint_dir, **kwargs):
+        pass
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+class PreEmphasis(torch.nn.Module):
+    # Buffer name must be `filter` to match the xtts-v2 checkpoint keys.
+    def __init__(self, coef: float = 0.97):
+        super().__init__()
+        self.coef = coef
+        self.register_buffer(
+            "filter",
+            torch.FloatTensor([-self.coef, 1.0]).unsqueeze(0).unsqueeze(0),
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        input = torch.nn.functional.pad(input.unsqueeze(1), (1, 0), "reflect")
+        return torch.nn.functional.conv1d(input, self.filter).squeeze(1)
+
+
+def TorchMelSpectrogram(**kwargs) -> nn.Sequential:
+    """Sequential[PreEmphasis, MelSpectrogram] so checkpoint keys load without remapping."""
+    import torchaudio
+
+    return nn.Sequential(
+        PreEmphasis(0.97),
+        torchaudio.transforms.MelSpectrogram(
+            sample_rate=16000,
+            n_fft=512,
+            win_length=400,
+            hop_length=160,
+            window_fn=torch.hamming_window,
+            n_mels=64,
+        ),
+    )
+
+
+class BaseEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.use_torch_spec = False
+
+    def get_torch_mel_spectrogram_class(self, audio_config):
+        return TorchMelSpectrogram()
+        
+    def inference(self, x, l2_norm=True):
+        return self.forward(x, l2_norm)        
+
+def get_user_data_dir(appname: str) -> Path:
+    """
+    Return OS-specific user data directory for caching.
+    """
+    if sys.platform == "win32":
+        import winreg
+
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
+        )
+        dir_, _ = winreg.QueryValueEx(key, "Local AppData")
+        ans = Path(dir_).resolve(strict=False)
+
+    elif sys.platform == "darwin":
+        ans = Path("~/Library/Application Support/").expanduser()
+
+    else:
+        ans = Path.home().joinpath(".local/share")
+
+    path = ans.joinpath(appname)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_fsspec(
+    path: str,
+    map_location: Union[
+        str,
+        Callable,
+        torch.device,
+        Dict[Union[str, torch.device], Union[str, torch.device]],
+    ] = None,
+    cache: bool = True,
+    **kwargs,
+) -> Any:
+    """
+    Like torch.load but supports remote paths via fsspec.
+
+    Supports:
+    - local files
+    - http(s)
+    - s3
+    - gcs
+    - hf hub
+    - any fsspec backend
+
+    If cache=True, remote files are cached locally.
+    """
+
+    is_local = os.path.isdir(path) or os.path.isfile(path)
+
+    if cache and not is_local:
+        with fsspec.open(
+            f"filecache::{path}",
+            filecache={"cache_storage": str(get_user_data_dir("tts_cache"))},
+            mode="rb",
+        ) as f:
+            return torch.load(f, map_location=map_location, **kwargs)
+
+    else:
+        with fsspec.open(path, "rb") as f:
+            return torch.load(f, map_location=map_location, **kwargs)
+            
+
+class SELayer(nn.Module):
+    def __init__(self, channel, reduction=8):
+        super().__init__()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Linear(channel, channel // reduction),
+            nn.ReLU(inplace=True),
+            nn.Linear(channel // reduction, channel),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        b, c, _, _ = x.size()
+        y = self.avg_pool(x).view(b, c)
+        y = self.fc(y).view(b, c, 1, 1)
+        return x * y
+
+
+class SEBasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, inplanes, planes, stride=1, downsample=None, reduction=8):
+        super().__init__()
+        self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.se = SELayer(planes, reduction)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        residual = x
+
+        out = self.conv1(x)
+        out = self.relu(out)
+        out = self.bn1(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.se(out)
+
+        if self.downsample is not None:
+            residual = self.downsample(x)
+
+        out += residual
+        out = self.relu(out)
+        return out
+
+
+class ResNetSpeakerEncoder(BaseEncoder):
+    """Implementation of the model H/ASP without batch normalization in speaker embedding. This model was proposed in: https://arxiv.org/abs/2009.14153
+    Adapted from: https://github.com/clovaai/voxceleb_trainer
+    """
+
+    # pylint: disable=W0102
+    def __init__(
+        self,
+        input_dim=64,
+        proj_dim=512,
+        layers=[3, 4, 6, 3],
+        num_filters=[32, 64, 128, 256],
+        encoder_type="ASP",
+        log_input=False,
+        use_torch_spec=False,
+        audio_config=None,
+    ):
+        super().__init__()
+
+        self.encoder_type = encoder_type
+        self.input_dim = input_dim
+        self.log_input = log_input
+        self.use_torch_spec = use_torch_spec
+        self.audio_config = audio_config
+        self.proj_dim = proj_dim
+
+        self.conv1 = nn.Conv2d(1, num_filters[0], kernel_size=3, stride=1, padding=1)
+        self.relu = nn.ReLU(inplace=True)
+        self.bn1 = nn.BatchNorm2d(num_filters[0])
+
+        self.inplanes = num_filters[0]
+        self.layer1 = self.create_layer(SEBasicBlock, num_filters[0], layers[0])
+        self.layer2 = self.create_layer(SEBasicBlock, num_filters[1], layers[1], stride=(2, 2))
+        self.layer3 = self.create_layer(SEBasicBlock, num_filters[2], layers[2], stride=(2, 2))
+        self.layer4 = self.create_layer(SEBasicBlock, num_filters[3], layers[3], stride=(2, 2))
+
+        self.instancenorm = nn.InstanceNorm1d(input_dim)
+
+        if self.use_torch_spec:
+            self.torch_spec = self.get_torch_mel_spectrogram_class(audio_config)
+        else:
+            self.torch_spec = None
+
+        outmap_size = int(self.input_dim / 8)
+
+        self.attention = nn.Sequential(
+            nn.Conv1d(num_filters[3] * outmap_size, 128, kernel_size=1),
+            nn.ReLU(),
+            nn.BatchNorm1d(128),
+            nn.Conv1d(128, num_filters[3] * outmap_size, kernel_size=1),
+            nn.Softmax(dim=2),
+        )
+
+        if self.encoder_type == "SAP":
+            out_dim = num_filters[3] * outmap_size
+        elif self.encoder_type == "ASP":
+            out_dim = num_filters[3] * outmap_size * 2
+        else:
+            raise ValueError("Undefined encoder")
+
+        self.fc = nn.Linear(out_dim, proj_dim)
+
+        self._init_layers()
+
+    def _init_layers(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+    def create_layer(self, block, planes, blocks, stride=1):
+        downsample = None
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                nn.Conv2d(self.inplanes, planes * block.expansion, kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(block(self.inplanes, planes, stride, downsample))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.inplanes, planes))
+
+        return nn.Sequential(*layers)
+
+    # pylint: disable=R0201
+    def new_parameter(self, *size):
+        out = nn.Parameter(torch.FloatTensor(*size))
+        nn.init.xavier_normal_(out)
+        return out
+
+    def forward(self, x, l2_norm=False):
+        """Forward pass of the model.
+
+        Args:
+            x (Tensor): Raw waveform signal or spectrogram frames. If input is a waveform, `torch_spec` must be `True`
+                to compute the spectrogram on-the-fly.
+            l2_norm (bool): Whether to L2-normalize the outputs.
+
+        Shapes:
+            - x: :math:`(N, 1, T_{in})` or :math:`(N, D_{spec}, T_{in})`
+        """
+        x.squeeze_(1)
+        # if you torch spec compute it otherwise use the mel spec computed by the AP
+        if self.use_torch_spec:
+            x = self.torch_spec(x)
+
+        if self.log_input:
+            x = (x + 1e-6).log()
+        x = self.instancenorm(x).unsqueeze(1)
+
+        x = self.conv1(x)
+        x = self.relu(x)
+        x = self.bn1(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = x.reshape(x.size()[0], -1, x.size()[-1])
+
+        w = self.attention(x)
+
+        if self.encoder_type == "SAP":
+            x = torch.sum(x * w, dim=2)
+        elif self.encoder_type == "ASP":
+            mu = torch.sum(x * w, dim=2)
+            sg = torch.sqrt((torch.sum((x**2) * w, dim=2) - mu**2).clamp(min=1e-5))
+            x = torch.cat((mu, sg), 1)
+
+        x = x.view(x.size()[0], -1)
+        x = self.fc(x)
+
+        if l2_norm:
+            x = torch.nn.functional.normalize(x, p=2, dim=1)
+        return x
+
+
+# adopted from https://github.com/jik876/hifi-gan/blob/master/models.py
+import logging
+
+import torch
+from torch import nn
+from torch.nn import Conv1d, ConvTranspose1d
+from torch.nn import functional as F
+from torch.nn.utils.parametrizations import weight_norm
+from torch.nn.utils.parametrize import remove_parametrizations
+# from trainer.io import load_fsspec
+
+logger = logging.getLogger(__name__)
+
+LRELU_SLOPE = 0.1
+
+
+def get_padding(kernel_size: int, dilation: int = 1) -> int:
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+class ResBlock1(torch.nn.Module):
+    """Residual Block Type 1. It has 3 convolutional layers in each convolutional block.
+
+    Network::
+
+        x -> lrelu -> conv1_1 -> conv1_2 -> conv1_3 -> z -> lrelu -> conv2_1 -> conv2_2 -> conv2_3 -> o -> + -> o
+        |--------------------------------------------------------------------------------------------------|
+
+
+    Args:
+        channels (int): number of hidden channels for the convolutional layers.
+        kernel_size (int): size of the convolution filter in each layer.
+        dilations (list): list of dilation value for each conv layer in a block.
+    """
+
+    def __init__(self, channels, kernel_size=3, dilation=(1, 3, 5)):
+        super().__init__()
+        self.convs1 = nn.ModuleList(
+            [
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[0],
+                        padding=get_padding(kernel_size, dilation[0]),
+                    )
+                ),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[1],
+                        padding=get_padding(kernel_size, dilation[1]),
+                    )
+                ),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[2],
+                        padding=get_padding(kernel_size, dilation[2]),
+                    )
+                ),
+            ]
+        )
+
+        self.convs2 = nn.ModuleList(
+            [
+                weight_norm(
+                    Conv1d(channels, channels, kernel_size, 1, dilation=1, padding=get_padding(kernel_size, 1))
+                ),
+                weight_norm(
+                    Conv1d(channels, channels, kernel_size, 1, dilation=1, padding=get_padding(kernel_size, 1))
+                ),
+                weight_norm(
+                    Conv1d(channels, channels, kernel_size, 1, dilation=1, padding=get_padding(kernel_size, 1))
+                ),
+            ]
+        )
+
+    def forward(self, x):
+        """
+        Args:
+            x (Tensor): input tensor.
+        Returns:
+            Tensor: output tensor.
+        Shapes:
+            x: [B, C, T]
+        """
+        for c1, c2 in zip(self.convs1, self.convs2):
+            xt = F.leaky_relu(x, LRELU_SLOPE)
+            xt = c1(xt)
+            xt = F.leaky_relu(xt, LRELU_SLOPE)
+            xt = c2(xt)
+            x = xt + x
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs1:
+            remove_parametrizations(l, "weight")
+        for l in self.convs2:
+            remove_parametrizations(l, "weight")
+
+
+class ResBlock2(torch.nn.Module):
+    """Residual Block Type 2. It has 1 convolutional layers in each convolutional block.
+
+    Network::
+
+        x -> lrelu -> conv1-> -> z -> lrelu -> conv2-> o -> + -> o
+        |---------------------------------------------------|
+
+
+    Args:
+        channels (int): number of hidden channels for the convolutional layers.
+        kernel_size (int): size of the convolution filter in each layer.
+        dilations (list): list of dilation value for each conv layer in a block.
+    """
+
+    def __init__(self, channels, kernel_size=3, dilation=(1, 3)):
+        super().__init__()
+        self.convs = nn.ModuleList(
+            [
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[0],
+                        padding=get_padding(kernel_size, dilation[0]),
+                    )
+                ),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[1],
+                        padding=get_padding(kernel_size, dilation[1]),
+                    )
+                ),
+            ]
+        )
+
+    def forward(self, x):
+        for c in self.convs:
+            xt = F.leaky_relu(x, LRELU_SLOPE)
+            xt = c(xt)
+            x = xt + x
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs:
+            remove_parametrizations(l, "weight")
+
+
+class HifiganGenerator(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        resblock_type,
+        resblock_dilation_sizes,
+        resblock_kernel_sizes,
+        upsample_kernel_sizes,
+        upsample_initial_channel,
+        upsample_factors,
+        inference_padding=5,
+        cond_channels=0,
+        conv_pre_weight_norm=True,
+        conv_post_weight_norm=True,
+        conv_post_bias=True,
+        cond_in_each_up_layer=False,
+        pre_linear=None,
+    ):
+        r"""HiFiGAN Generator with Multi-Receptive Field Fusion (MRF)
+
+        Network:
+            x -> lrelu -> upsampling_layer -> resblock1_k1x1 -> z1 -> + -> z_sum / #resblocks -> lrelu -> conv_post_7x1 -> tanh -> o
+                                                 ..          -> zI ---|
+                                              resblockN_kNx1 -> zN ---'
+
+        Args:
+            in_channels (int): number of input tensor channels.
+            out_channels (int): number of output tensor channels.
+            resblock_type (str): type of the `ResBlock`. '1' or '2'.
+            resblock_dilation_sizes (List[List[int]]): list of dilation values in each layer of a `ResBlock`.
+            resblock_kernel_sizes (List[int]): list of kernel sizes for each `ResBlock`.
+            upsample_kernel_sizes (List[int]): list of kernel sizes for each transposed convolution.
+            upsample_initial_channel (int): number of channels for the first upsampling layer. This is divided by 2
+                for each consecutive upsampling layer.
+            upsample_factors (List[int]): upsampling factors (stride) for each upsampling layer.
+            inference_padding (int): constant padding applied to the input at inference time. Defaults to 5.
+            pre_linear (int): If not None, add nn.Linear(pre_linear, in_channels) before the convolutions.
+        """
+        super().__init__()
+        self.inference_padding = inference_padding
+        self.num_kernels = len(resblock_kernel_sizes)
+        self.num_upsamples = len(upsample_factors)
+        self.cond_in_each_up_layer = cond_in_each_up_layer
+
+        # initial upsampling layers
+        if pre_linear is not None:
+            self.lin_pre = nn.Linear(pre_linear, in_channels)
+        self.conv_pre = weight_norm(Conv1d(in_channels, upsample_initial_channel, 7, 1, padding=3))
+        resblock = ResBlock1 if resblock_type == "1" else ResBlock2
+        # upsampling layers
+        self.ups = nn.ModuleList()
+        for i, (u, k) in enumerate(zip(upsample_factors, upsample_kernel_sizes)):
+            self.ups.append(
+                weight_norm(
+                    ConvTranspose1d(
+                        upsample_initial_channel // (2**i),
+                        upsample_initial_channel // (2 ** (i + 1)),
+                        k,
+                        u,
+                        padding=(k - u) // 2,
+                    )
+                )
+            )
+        # MRF blocks
+        self.resblocks = nn.ModuleList()
+        for i in range(len(self.ups)):
+            ch = upsample_initial_channel // (2 ** (i + 1))
+            for _, (k, d) in enumerate(zip(resblock_kernel_sizes, resblock_dilation_sizes)):
+                self.resblocks.append(resblock(ch, k, d))
+        # post convolution layer
+        self.conv_post = weight_norm(Conv1d(ch, out_channels, 7, 1, padding=3, bias=conv_post_bias))
+        if cond_channels > 0:
+            self.cond_layer = nn.Conv1d(cond_channels, upsample_initial_channel, 1)
+
+        if not conv_pre_weight_norm:
+            remove_parametrizations(self.conv_pre, "weight")
+
+        if not conv_post_weight_norm:
+            remove_parametrizations(self.conv_post, "weight")
+
+        if self.cond_in_each_up_layer:
+            self.conds = nn.ModuleList()
+            for i in range(len(self.ups)):
+                ch = upsample_initial_channel // (2 ** (i + 1))
+                self.conds.append(nn.Conv1d(cond_channels, ch, 1))
+
+    def forward(self, x, g=None):
+        """
+        Args:
+            x (Tensor): feature input tensor.
+            g (Tensor): global conditioning input tensor.
+
+        Returns:
+            Tensor: output waveform.
+
+        Shapes:
+            x: [B, C, T]
+            Tensor: [B, 1, T]
+        """
+        if hasattr(self, "lin_pre"):
+            x = self.lin_pre(x)
+            x = x.permute(0, 2, 1)
+        o = self.conv_pre(x)
+        if hasattr(self, "cond_layer"):
+            o = o + self.cond_layer(g)
+        for i in range(self.num_upsamples):
+            o = F.leaky_relu(o, LRELU_SLOPE)
+            o = self.ups[i](o)
+
+            if self.cond_in_each_up_layer:
+                o = o + self.conds[i](g)
+
+            z_sum = None
+            for j in range(self.num_kernels):
+                if z_sum is None:
+                    z_sum = self.resblocks[i * self.num_kernels + j](o)
+                else:
+                    z_sum += self.resblocks[i * self.num_kernels + j](o)
+            o = z_sum / self.num_kernels
+        o = F.leaky_relu(o)
+        o = self.conv_post(o)
+        o = torch.tanh(o)
+        return o
+
+    @torch.inference_mode()
+    def inference(self, c):
+        """
+        Args:
+            x (Tensor): conditioning input tensor.
+
+        Returns:
+            Tensor: output waveform.
+
+        Shapes:
+            x: [B, C, T]
+            Tensor: [B, 1, T]
+        """
+        c = c.to(self.conv_pre.weight.device)
+        c = torch.nn.functional.pad(c, (self.inference_padding, self.inference_padding), "replicate")
+        return self.forward(c)
+
+    def remove_weight_norm(self):
+        logger.info("Removing weight norm...")
+        for l in self.ups:
+            remove_parametrizations(l, "weight")
+        for l in self.resblocks:
+            l.remove_weight_norm()
+        remove_parametrizations(self.conv_pre, "weight")
+        remove_parametrizations(self.conv_post, "weight")
+
+    def load_checkpoint(self, config, checkpoint_path, eval=False, cache=False):  # pylint: disable=unused-argument, redefined-builtin
+        state = load_fsspec(checkpoint_path, map_location=torch.device("cpu"), cache=cache)
+        self.load_state_dict(state["model"])
+        if eval:
+            self.eval()
+            assert not self.training
+            self.remove_weight_norm()
+
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class HifiDecoder(torch.nn.Module):
+    def __init__(
+        self,
+        input_sample_rate=22050,
+        output_sample_rate=24000,
+        output_hop_length=256,
+        ar_mel_length_compression=1024,
+        decoder_input_dim=1024,
+        resblock_type_decoder="1",
+        resblock_dilation_sizes_decoder=[[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        resblock_kernel_sizes_decoder=[3, 7, 11],
+        upsample_rates_decoder=[8, 8, 2, 2],
+        upsample_initial_channel_decoder=512,
+        upsample_kernel_sizes_decoder=[16, 16, 4, 4],
+        d_vector_dim=512,
+        cond_d_vector_in_each_upsampling_layer=True,
+        speaker_encoder_audio_config={
+            "fft_size": 512,
+            "win_length": 400,
+            "hop_length": 160,
+            "sample_rate": 16000,
+            "preemphasis": 0.97,
+            "num_mels": 64,
+        },
+    ):
+        super().__init__()
+        self.input_sample_rate = input_sample_rate
+        self.output_sample_rate = output_sample_rate
+        self.output_hop_length = output_hop_length
+        self.ar_mel_length_compression = ar_mel_length_compression
+        self.speaker_encoder_audio_config = speaker_encoder_audio_config
+        self.waveform_decoder = HifiganGenerator(
+            decoder_input_dim,
+            1,
+            resblock_type_decoder,
+            resblock_dilation_sizes_decoder,
+            resblock_kernel_sizes_decoder,
+            upsample_kernel_sizes_decoder,
+            upsample_initial_channel_decoder,
+            upsample_rates_decoder,
+            inference_padding=0,
+            cond_channels=d_vector_dim,
+            conv_pre_weight_norm=False,
+            conv_post_weight_norm=False,
+            conv_post_bias=False,
+            cond_in_each_up_layer=cond_d_vector_in_each_upsampling_layer,
+        )
+        self.speaker_encoder = ResNetSpeakerEncoder(
+            input_dim=64,
+            proj_dim=512,
+            log_input=True,
+            use_torch_spec=True,
+            audio_config=speaker_encoder_audio_config,
+        )
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def forward(self, latents, g=None):
+        """
+        Args:
+            x (Tensor): feature input tensor (GPT latent).
+            g (Tensor): global conditioning input tensor.
+
+        Returns:
+            Tensor: output waveform.
+
+        Shapes:
+            x: [B, C, T]
+            Tensor: [B, 1, T]
+        """
+
+        z = torch.nn.functional.interpolate(
+            latents.transpose(1, 2),
+            scale_factor=[self.ar_mel_length_compression / self.output_hop_length],
+            mode="linear",
+        ).squeeze(1)
+        # upsample to the right sr
+        if self.output_sample_rate != self.input_sample_rate:
+            z = torch.nn.functional.interpolate(
+                z,
+                scale_factor=[self.output_sample_rate / self.input_sample_rate],
+                mode="linear",
+            ).squeeze(0)
+        o = self.waveform_decoder(z, g=g)
+        return o
+
+    @torch.inference_mode()
+    def inference(self, c, g):
+        """
+        Args:
+            x (Tensor): feature input tensor (GPT latent).
+            g (Tensor): global conditioning input tensor.
+
+        Returns:
+            Tensor: output waveform.
+
+        Shapes:
+            x: [B, C, T]
+            Tensor: [B, 1, T]
+        """
+        return self.forward(c, g=g)
+
+    def load_checkpoint(self, checkpoint_path, eval=False):  # pylint: disable=unused-argument, redefined-builtin
+        state = load_fsspec(checkpoint_path, map_location=torch.device("cpu"))
+        # remove unused keys
+        state = state["model"]
+        states_keys = list(state.keys())
+        for key in states_keys:
+            if "waveform_decoder." not in key and "speaker_encoder." not in key:
+                del state[key]
+
+        self.load_state_dict(state)
+        if eval:
+            self.eval()
+            assert not self.training
+            self.waveform_decoder.remove_weight_norm()
+
+
+### Start
+import torch.nn as nn
+import torch
+import math
+
+def zero_module(module):
+    """
+    Zero out the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+class GroupNorm32(nn.GroupNorm):
+    """GroupNorm always computed in fp32 for numerical stability."""
+
+    def forward(self, x):
+        out = F.group_norm(
+            x.float(),
+            self.num_groups,
+            self.weight.float() if self.weight is not None else None,
+            self.bias.float() if self.bias is not None else None,
+            self.eps,
+        )
+        return out.type(x.dtype)
+
+
+def normalization(channels):
+    """
+    Make a standard normalization layer.
+
+    :param channels: number of input channels.
+    :return: an nn.Module for normalization.
+    """
+    groups = 32
+    if channels <= 16:
+        groups = 8
+    elif channels <= 64:
+        groups = 16
+    while channels % groups != 0:
+        groups = int(groups / 2)
+    assert groups > 2
+    return GroupNorm32(groups, channels)
+
+class QKVAttentionLegacy(nn.Module):
+    """
+    A module which performs QKV attention. Matches legacy QKVAttention + input/output heads shaping
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv, mask=None, rel_pos=None):
+        """
+        Apply QKV attention.
+
+        :param qkv: an [N x (H * 3 * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum("bct,bcs->bts", q * scale, k * scale)  # More stable with f16 than dividing afterwards
+        if rel_pos is not None:
+            weight = rel_pos(weight.reshape(bs, self.n_heads, weight.shape[-2], weight.shape[-1])).reshape(
+                bs * self.n_heads, weight.shape[-2], weight.shape[-1]
+            )
+        if mask is not None:
+            mask = mask.repeat(self.n_heads, 1, 1)
+            weight[mask.logical_not()] = -torch.inf
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v)
+
+        return a.reshape(bs, -1, length)
+
+from einops import rearrange
+class RelativePositionBias(nn.Module):
+    def __init__(self, scale, causal=False, num_buckets=32, max_distance=128, heads=8):
+        super().__init__()
+        self.scale = scale
+        self.causal = causal
+        self.num_buckets = num_buckets
+        self.max_distance = max_distance
+        self.relative_attention_bias = nn.Embedding(num_buckets, heads)
+
+    @staticmethod
+    def _relative_position_bucket(relative_position, causal=True, num_buckets=32, max_distance=128):
+        ret = 0
+        n = -relative_position
+        if not causal:
+            num_buckets //= 2
+            ret += (n < 0).long() * num_buckets
+            n = torch.abs(n)
+        else:
+            n = torch.max(n, torch.zeros_like(n))
+
+        max_exact = num_buckets // 2
+        is_small = n < max_exact
+
+        val_if_large = (
+            max_exact
+            + (torch.log(n.float() / max_exact) / math.log(max_distance / max_exact) * (num_buckets - max_exact)).long()
+        )
+        val_if_large = torch.min(val_if_large, torch.full_like(val_if_large, num_buckets - 1))
+
+        ret += torch.where(is_small, n, val_if_large)
+        return ret
+
+    def forward(self, qk_dots):
+        i, j, device = *qk_dots.shape[-2:], qk_dots.device
+        q_pos = torch.arange(i, dtype=torch.long, device=device)
+        k_pos = torch.arange(j, dtype=torch.long, device=device)
+        rel_pos = k_pos[None, :] - q_pos[:, None]
+        rp_bucket = self._relative_position_bucket(
+            rel_pos, causal=self.causal, num_buckets=self.num_buckets, max_distance=self.max_distance
+        )
+        values = self.relative_attention_bias(rp_bucket)
+        bias = rearrange(values, "i j h -> () h i j")
+        return qk_dots + (bias * self.scale)
+
+class AttentionBlock(nn.Module):
+    """
+    An attention block that allows spatial positions to attend to each other.
+
+    Originally ported from here, but adapted to the N-d case.
+    https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/models/unet.py#L66.
+    """
+
+    def __init__(
+        self,
+        channels,
+        num_heads=1,
+        num_head_channels=-1,
+        *,
+        relative_pos_embeddings=False,
+        tortoise_norm=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        if num_head_channels == -1:
+            self.num_heads = num_heads
+        else:
+            assert channels % num_head_channels == 0, (
+                f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            )
+            self.num_heads = channels // num_head_channels
+        self.norm = normalization(channels)
+        self.qkv = nn.Conv1d(channels, channels * 3, 1)
+        # split heads before split qkv
+        self.attention = QKVAttentionLegacy(self.num_heads)
+        self.tortoise_norm = tortoise_norm
+
+        self.proj_out = zero_module(nn.Conv1d(channels, channels, 1))
+        if relative_pos_embeddings:
+            self.relative_pos_embeddings = RelativePositionBias(
+                scale=(channels // self.num_heads) ** 0.5,
+                causal=False,
+                heads=num_heads,
+                num_buckets=32,
+                max_distance=64,
+            )
+        else:
+            self.relative_pos_embeddings = None
+
+    def forward(self, x, mask=None):
+        b, c, *spatial = x.shape
+        x = x.reshape(b, c, -1)
+        x_norm = self.norm(x)
+        qkv = self.qkv(x_norm)
+        h = self.attention(qkv, mask, self.relative_pos_embeddings)
+        h = self.proj_out(h)
+        if self.tortoise_norm:
+            return (x + h).reshape(b, c, *spatial)
+        return (x_norm + h).reshape(b, c, *spatial)
+
+class ConditioningEncoder(nn.Module):
+    def __init__(
+        self,
+        spec_dim,
+        embedding_dim,
+        attn_blocks=6,
+        num_attn_heads=4,
+        *,
+        tortoise_norm=False,
+    ):
+        super().__init__()
+        attn = []
+        self.init = nn.Conv1d(spec_dim, embedding_dim, kernel_size=1)
+        for a in range(attn_blocks):
+            attn.append(AttentionBlock(embedding_dim, num_attn_heads, tortoise_norm=tortoise_norm))
+        self.attn = nn.Sequential(*attn)
+        self.dim = embedding_dim
+
+    def forward(self, x):
+        """
+        x: (b, 80, s)
+        """
+        h = self.init(x)
+        h = self.attn(h)
+        return h
+
+################################ Perceiver Resampler ##########################################
+from torch import einsum, nn
+from einops import rearrange, repeat
+from einops.layers.torch import Rearrange
+from collections import namedtuple
+from functools import wraps
+
+def exists(val):
+    return val is not None
+
+def default(val, d):
+    return val if exists(val) else d
+
+def once(fn):
+    called = False
+
+    @wraps(fn)
+    def inner(x):
+        nonlocal called
+        if called:
+            return
+        called = True
+        return fn(x)
+
+    return inner
+
+
+print_once = once(print)
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim, scale=True, dim_cond=None):
+        super().__init__()
+        self.cond = exists(dim_cond)
+        self.to_gamma_beta = nn.Linear(dim_cond, dim * 2) if self.cond else None
+
+        self.scale = dim**0.5
+        self.gamma = nn.Parameter(torch.ones(dim)) if scale else None
+
+    def forward(self, x, cond=None):
+        gamma = default(self.gamma, 1)
+        out = F.normalize(x, dim=-1) * self.scale * gamma
+
+        if not self.cond:
+            return out
+
+        assert exists(cond)
+        gamma, beta = self.to_gamma_beta(cond).chunk(2, dim=-1)
+        gamma, beta = map(lambda t: rearrange(t, "b d -> b 1 d"), (gamma, beta))
+        return out * gamma + beta
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        dim,
+        *,
+        dim_context=None,
+        causal=False,
+        dim_head=64,
+        heads=8,
+        dropout=0.0,
+        use_flash=False,
+        cross_attn_include_queries=False,
+    ):
+        super().__init__()
+        self.scale = dim_head**-0.5
+        self.heads = heads
+        self.cross_attn_include_queries = cross_attn_include_queries
+
+        dim_inner = dim_head * heads
+        dim_context = default(dim_context, dim)
+
+        self.attend = Attend(causal=causal, dropout=dropout, use_flash=use_flash)
+        self.to_q = nn.Linear(dim, dim_inner, bias=False)
+        self.to_kv = nn.Linear(dim_context, dim_inner * 2, bias=False)
+        self.to_out = nn.Linear(dim_inner, dim, bias=False)
+
+    def forward(self, x, context=None, mask=None):
+        h, has_context = self.heads, exists(context)
+
+        context = default(context, x)
+
+        if has_context and self.cross_attn_include_queries:
+            context = torch.cat((x, context), dim=-2)
+
+        q, k, v = (self.to_q(x), *self.to_kv(context).chunk(2, dim=-1))
+        q, k, v = map(lambda t: rearrange(t, "b n (h d) -> b h n d", h=h), (q, k, v))
+
+        out = self.attend(q, k, v, mask=mask)
+
+        out = rearrange(out, "b h n d -> b n (h d)")
+        return self.to_out(out)
+class Attend(nn.Module):
+    def __init__(self, dropout=0.0, causal=False, use_flash=False):
+        super().__init__()
+        self.dropout = dropout
+        self.attn_dropout = nn.Dropout(dropout)
+
+        self.causal = causal
+        self.register_buffer("mask", None, persistent=False)
+
+        self.use_flash = use_flash
+
+        # determine efficient attention configs for cuda and cpu
+        self.config = namedtuple("EfficientAttentionConfig", ["enable_flash", "enable_math", "enable_mem_efficient"])
+        self.cpu_config = self.config(True, True, True)
+        self.cuda_config = None
+
+        if not torch.cuda.is_available() or not use_flash:
+            return
+
+        device_properties = torch.cuda.get_device_properties(torch.device("cuda"))
+
+        if device_properties.major == 8 and device_properties.minor == 0:
+            print_once("A100 GPU detected, using flash attention if input tensor is on cuda")
+            self.cuda_config = self.config(True, False, False)
+        else:
+            print_once("Non-A100 GPU detected, using math or mem efficient attention if input tensor is on cuda")
+            self.cuda_config = self.config(False, True, True)
+
+    def get_mask(self, n, device):
+        if exists(self.mask) and self.mask.shape[-1] >= n:
+            return self.mask[:n, :n]
+
+        mask = torch.ones((n, n), device=device, dtype=torch.bool).triu(1)
+        self.register_buffer("mask", mask, persistent=False)
+        return mask
+
+    def flash_attn(self, q, k, v, mask=None):
+        _, heads, q_len, _, k_len, is_cuda = *q.shape, k.shape[-2], q.is_cuda
+
+        # Recommended for multi-query single-key-value attention by Tri Dao
+        # kv shape torch.Size([1, 512, 64]) -> torch.Size([1, 8, 512, 64])
+
+        if k.ndim == 3:
+            k = rearrange(k, "b ... -> b 1 ...").expand_as(q)
+
+        if v.ndim == 3:
+            v = rearrange(v, "b ... -> b 1 ...").expand_as(q)
+
+        # Check if mask exists and expand to compatible shape
+        # The mask is B L, so it would have to be expanded to B H N L
+
+        if exists(mask):
+            mask = rearrange(mask, "b j -> b 1 1 j")
+            mask = mask.expand(-1, heads, q_len, -1)
+
+        # Check if there is a compatible device for flash attention
+
+        config = self.cuda_config if is_cuda else self.cpu_config
+
+        # pytorch 2.0 flash attn: q, k, v, mask, dropout, causal, softmax_scale
+
+        with torch.backends.cuda.sdp_kernel(**config._asdict()):
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, dropout_p=self.dropout if self.training else 0.0, is_causal=self.causal
+            )
+
+        return out
+
+    def forward(self, q, k, v, mask=None):
+        """
+        einstein notation
+        b - batch
+        h - heads
+        n, i, j - sequence length (base sequence length, source, target)
+        d - feature dimension
+        """
+
+        n, device = q.shape[-2], q.device
+
+        scale = q.shape[-1] ** -0.5
+
+        if self.use_flash:
+            return self.flash_attn(q, k, v, mask=mask)
+
+        kv_einsum_eq = "b j d" if k.ndim == 3 else "b h j d"
+
+        # similarity
+
+        sim = einsum(f"b h i d, {kv_einsum_eq} -> b h i j", q, k) * scale
+
+        # key padding mask
+
+        if exists(mask):
+            mask = rearrange(mask, "b j -> b 1 1 j")
+            sim = sim.masked_fill(~mask, -torch.finfo(sim.dtype).max)
+
+        # causal mask
+
+        if self.causal:
+            causal_mask = self.get_mask(n, device)
+            sim = sim.masked_fill(causal_mask, -torch.finfo(sim.dtype).max)
+
+        # attention
+
+        attn = sim.softmax(dim=-1)
+        attn = self.attn_dropout(attn)
+
+        # aggregate values
+
+        out = einsum(f"b h i j, {kv_einsum_eq} -> b h i d", attn, v)
+
+        return out
+
+
+class CausalConv1d(nn.Conv1d):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        (kernel_size,) = self.kernel_size
+        (dilation,) = self.dilation
+        (stride,) = self.stride
+
+        assert stride == 1
+        self.causal_padding = dilation * (kernel_size - 1)
+
+    def forward(self, x):
+        causal_padded_x = F.pad(x, (self.causal_padding, 0), value=0.0)
+        return super().forward(causal_padded_x)
+
+import torch.nn.functional as F
+class GEGLU(nn.Module):
+    def forward(self, x):
+        x, gates = x.chunk(2, dim=-1)
+        return x * F.gelu(gates)
+
+def FeedForward(dim, mult=4, causal_conv=False):
+    dim_inner = int(dim * mult * 2 / 3)
+
+    conv = None
+    if causal_conv:
+        conv = nn.Sequential(
+            Rearrange("b n d -> b d n"),
+            CausalConv1d(dim_inner, dim_inner, 3),
+            Rearrange("b d n -> b n d"),
+        )
+
+    return Sequential(nn.Linear(dim, dim_inner * 2), GEGLU(), conv, nn.Linear(dim_inner, dim))
+
+def Sequential(*mods):
+    return nn.Sequential(*filter(exists, mods))
+
+class PerceiverResampler(nn.Module):
+    def __init__(
+        self,
+        *,
+        dim,
+        depth=2,
+        dim_context=None,
+        num_latents=32,
+        dim_head=64,
+        heads=8,
+        ff_mult=4,
+        use_flash_attn=False,
+    ):
+        super().__init__()
+        dim_context = default(dim_context, dim)
+
+        self.proj_context = nn.Linear(dim_context, dim) if dim_context != dim else nn.Identity()
+
+        self.latents = nn.Parameter(torch.randn(num_latents, dim))
+        nn.init.normal_(self.latents, std=0.02)
+
+        self.layers = nn.ModuleList([])
+        for _ in range(depth):
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        Attention(
+                            dim=dim,
+                            dim_head=dim_head,
+                            heads=heads,
+                            use_flash=use_flash_attn,
+                            cross_attn_include_queries=True,
+                        ),
+                        FeedForward(dim=dim, mult=ff_mult),
+                    ]
+                )
+            )
+
+        self.norm = RMSNorm(dim)
+
+    def forward(self, x, mask=None):
+        batch = x.shape[0]
+
+        x = self.proj_context(x)
+
+        latents = repeat(self.latents, "n d -> b n d", b=batch)
+
+        for attn, ff in self.layers:
+            latents = attn(latents, x, mask=mask) + latents
+            latents = ff(latents) + latents
+
+        return self.norm(latents)

--- a/vox_serve/model/__init__.py
+++ b/vox_serve/model/__init__.py
@@ -11,6 +11,7 @@ from .glm_voice import GLMVoiceModel
 from .orpheus import OrpheusModel
 from .qwen3_tts import Qwen3TTSModel
 from .step_audio_2 import StepAudio2Model
+from .xtts import XTTSModel
 from .zonos import ZonosModel
 
 # Registry mapping model name patterns to model classes
@@ -29,6 +30,8 @@ MODEL_REGISTRY: Dict[str, Type[BaseLM]] = {
     "ResembleAI/chatterbox": ChatterboxModel,
     "cosyvoice2": CosyVoice2Model,
     "FunAudioLLM/CosyVoice2-0.5B": CosyVoice2Model,
+    "xtts": XTTSModel,
+    "coqui/xtts-v2": XTTSModel,
     "qwen3-tts": Qwen3TTSModel,
     "qwen3-tts-base": Qwen3TTSModel,
     "qwen3-tts-voice-design": Qwen3TTSModel,

--- a/vox_serve/model/xtts.py
+++ b/vox_serve/model/xtts.py
@@ -1,0 +1,1394 @@
+import json
+import os
+import pickle
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Coroutine, List, Tuple
+
+import torch
+import torch.nn.functional as F
+import torchaudio
+from torch import nn
+from huggingface_hub import hf_hub_download
+
+from ..flashinfer_utils import FlashInferWrapper
+from ..encoder.xtts import (
+    ConditioningEncoder,
+    HifiDecoder,
+    PerceiverResampler,
+    load_fsspec,
+)
+from ..requests import Request
+from ..sampling import Sampler, SamplingConfig
+from ..tokenizer.base import DecoderCache
+from ..tokenizer.xtts import VoiceBpeTokenizer
+from .base import BaseLM, PreprocessOutput
+
+
+@dataclass
+class XttsAudioConfig:
+    """
+    Configuration class for audio-related parameters in the XTTS model.
+
+    Args:
+        sample_rate (int): The sample rate in which the GPT operates.
+        output_sample_rate (int): The sample rate of the output audio waveform.
+        dvae_sample_rate (int): The sample rate of the DVAE
+    """
+
+    sample_rate: int = 22050
+    output_sample_rate: int = 24000
+    dvae_sample_rate: int = 22050
+
+
+@dataclass
+class XttsArgs:
+    """A dataclass to represent XTTS model arguments that define the model structure.
+
+    Args:
+        gpt_batch_size (int): The size of the auto-regressive batch.
+        enable_redaction (bool, optional): Whether to enable redaction. Defaults to True.
+        kv_cache (bool, optional): Whether to use the kv_cache. Defaults to True.
+        gpt_checkpoint (str, optional): The checkpoint for the autoregressive model. Defaults to None.
+        clvp_checkpoint (str, optional): The checkpoint for the ConditionalLatentVariablePerseq model. Defaults to None.
+        decoder_checkpoint (str, optional): The checkpoint for the DiffTTS model. Defaults to None.
+        num_chars (int, optional): The maximum number of characters to generate. Defaults to 255.
+
+        For GPT model:
+        gpt_max_audio_tokens (int, optional): The maximum mel tokens for the autoregressive model. Defaults to 604.
+        gpt_max_text_tokens (int, optional): The maximum text tokens for the autoregressive model. Defaults to 402.
+        gpt_max_prompt_tokens (int, optional): The maximum prompt tokens or the autoregressive model. Defaults to 70.
+        gpt_layers (int, optional): The number of layers for the autoregressive model. Defaults to 30.
+        gpt_n_model_channels (int, optional): The model dimension for the autoregressive model. Defaults to 1024.
+        gpt_n_heads (int, optional): The number of heads for the autoregressive model. Defaults to 16.
+        gpt_number_text_tokens (int, optional): The number of text tokens for the autoregressive model. Defaults to 255.
+        gpt_start_text_token (int, optional): The start text token for the autoregressive model. Defaults to 255.
+        gpt_checkpointing (bool, optional): Whether to use checkpointing for the autoregressive model. Defaults to False.
+        gpt_train_solo_embeddings (bool, optional): Whether to train embeddings for the autoregressive model. Defaults to False.
+        gpt_code_stride_len (int, optional): The hop_size of dvae and consequently of the gpt output. Defaults to 1024.
+        gpt_use_masking_gt_prompt_approach (bool, optional):  If True, it will use ground truth as prompt and it will mask the loss to avoid repetition. Defaults to True.
+        gpt_use_perceiver_resampler (bool, optional):  If True, it will use perceiver resampler from flamingo paper - https://arxiv.org/abs/2204.14198. Defaults to False.
+    """
+
+    gpt_batch_size: int = 1
+    enable_redaction: bool = False
+    kv_cache: bool = True
+    gpt_checkpoint: str = None
+    clvp_checkpoint: str = None
+    decoder_checkpoint: str = None
+    num_chars: int = 255
+
+    # XTTS GPT Encoder params
+    tokenizer_file: str = ""
+    gpt_max_audio_tokens: int = 605
+    gpt_max_text_tokens: int = 402
+    gpt_max_prompt_tokens: int = 70
+    gpt_layers: int = 30
+    gpt_n_model_channels: int = 1024
+    gpt_n_heads: int = 16
+    gpt_number_text_tokens: int = None
+    gpt_start_text_token: int = None
+    gpt_stop_text_token: int = None
+    gpt_num_audio_tokens: int = 8194
+    gpt_start_audio_token: int = 8192
+    gpt_stop_audio_token: int = 8193
+    gpt_code_stride_len: int = 1024
+    gpt_use_masking_gt_prompt_approach: bool = True
+    gpt_use_perceiver_resampler: bool = False
+
+    # HifiGAN Decoder params
+    input_sample_rate: int = 22050
+    output_sample_rate: int = 24000
+    output_hop_length: int = 256
+    decoder_input_dim: int = 1024
+    d_vector_dim: int = 512
+    cond_d_vector_in_each_upsampling_layer: bool = True
+
+    # constants
+    duration_const: int = 102400
+
+
+@dataclass
+class XttsConfig:
+    """Defines parameters for XTTS TTS model.
+
+    Args:
+        model (str):
+            Model name. Do not change unless you know what you are doing.
+
+        model_args (XttsArgs):
+            Model architecture arguments. Defaults to `XttsArgs()`.
+
+        audio (XttsAudioConfig):
+            Audio processing configuration. Defaults to `XttsAudioConfig()`.
+
+        temperature (float):
+            Temperature for the autoregressive model inference. Larger values makes predictions more creative sacrificing stability. Defaults to `0.2`.
+
+        length_penalty (float):
+            Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to the sequence length,
+            which in turn is used to divide the score of the sequence. Since the score is the log likelihood of the sequence (i.e. negative),
+            length_penalty > 0.0 promotes longer sequences, while length_penalty < 0.0 encourages shorter sequences.
+
+        repetition_penalty (float):
+            The parameter for repetition penalty. 1.0 means no penalty. Defaults to `2.0`.
+
+        top_p (float):
+            If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to top_p or higher are kept for generation.
+            Defaults to `0.8`.
+
+        num_gpt_outputs (int):
+            Number of samples taken from the autoregressive model, all of which are filtered using CLVP.
+            As XTTS is a probabilistic model, more samples means a higher probability of creating something "great".
+            Defaults to `16`.
+
+        gpt_cond_len (int):
+            Length of the audio used as conditioning for the autoregressive  model. If audio is shorter,
+            then audio length is used else the first `gpt_cond_len` secs is used. Defaults to 12 seconds.
+
+        gpt_cond_chunk_len (int):
+            Audio chunk size in seconds. Audio is split into chunks and latents are extracted for each chunk. Then
+            the latents are averaged. Chunking improves the stability. It must be <= gpt_cond_len.
+            If gpt_cond_len == gpt_cond_chunk_len, no chunking. Defaults to `4` seconds.
+
+        max_ref_len (int):
+            Maximum number of seconds of audio to be used as conditioning for the decoder. Defaults to `10`.
+
+        sound_norm_refs (bool):
+            Whether to normalize the conditioning audio. Defaults to `False`.
+
+    Note:
+        Check :class:`TTS.tts.configs.shared_configs.BaseTTSConfig` for the inherited parameters.
+
+    Example:
+
+        >>> from TTS.tts.configs.xtts_config import XttsConfig
+        >>> config = XttsConfig()
+    """
+
+    model: str = "xtts"
+    _supports_cloning: bool = True
+    # model specific params
+    model_args: XttsArgs = field(default_factory=XttsArgs)
+    audio: XttsAudioConfig = field(default_factory=XttsAudioConfig)
+    languages: list[str] = field(
+        default_factory=lambda: [
+            "en",
+            "es",
+            "fr",
+            "de",
+            "it",
+            "pt",
+            "pl",
+            "tr",
+            "ru",
+            "nl",
+            "cs",
+            "ar",
+            "zh-cn",
+            "hu",
+            "ko",
+            "ja",
+            "hi",
+        ]
+    )
+
+    # inference params
+    temperature: float = 0.85
+    length_penalty: float = 1.0
+    repetition_penalty: float = 2.0
+    top_k: int = 50
+    top_p: float = 0.85
+    num_gpt_outputs: int = 1
+
+    # cloning
+    gpt_cond_len: int = 12
+    gpt_cond_chunk_len: int = 4
+    max_ref_len: int = 10
+    sound_norm_refs: bool = False
+
+    # new config
+    checkpoint_path: str = "~/.local/share/tts/tts_models--multilingual--multi-dataset--xtts_v2"
+    repo_id: str = "coqui/XTTS-v2"
+    layer_norm_epsilon=1e-5
+
+    def load_json(self, path):
+        import json
+        with open(path, "r") as f:
+            data = json.load(f)
+        for key, value in data.items():
+            current = getattr(self, key, None)
+            if isinstance(value, dict) and hasattr(current, "__dict__"):
+                for k, v in value.items():
+                    setattr(current, k, v)
+            else:
+                setattr(self, key, value)
+        return self
+    
+    def to_dict(self):
+        return self.__dict__.copy()
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+        
+    def __contains__(self, key):
+        return hasattr(self, key)
+
+
+class LearnedPositionEmbeddings(nn.Module):
+    def __init__(self, seq_len, model_dim, init=0.02, relative=False):
+        super().__init__()
+        self.emb = nn.Embedding(seq_len, model_dim)
+        self.emb.weight.data.normal_(mean=0.0, std=init)
+        self.relative = relative
+        self.seq_len = seq_len
+
+    def forward(self, x):
+        sl = x.shape[1]
+        if self.relative:
+            import random
+            start = random.randint(sl, self.seq_len) - sl
+            return self.emb(torch.arange(start, start + sl, device=x.device))
+        else:
+            return self.emb(torch.arange(0, sl, device=x.device))
+
+    def get_fixed_embedding(self, ind, dev):
+        return self.emb(torch.tensor([ind], device=dev)).unsqueeze(0)
+
+
+class XttsGptMLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.c_fc = nn.Linear(hidden_size, intermediate_size)
+        self.act = nn.GELU(approximate="tanh")
+        self.c_proj = nn.Linear(intermediate_size, hidden_size)
+
+    def forward(self, hidden_states):
+        hidden_states = self.c_fc(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.c_proj(hidden_states)
+        return hidden_states
+
+class XttsGptAttention(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.q_proj = nn.Linear(hidden_size, hidden_size)
+        self.k_proj = nn.Linear(hidden_size, hidden_size)
+        self.v_proj = nn.Linear(hidden_size, hidden_size)
+        self.out_proj = nn.Linear(hidden_size, hidden_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.LongTensor,
+        attn_wrapper: FlashInferWrapper,
+        kv_cache: torch.Tensor,
+    ):
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, self.num_heads, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape)
+        key_states = self.k_proj(hidden_states).view(hidden_shape)
+        value_states = self.v_proj(hidden_states).view(hidden_shape)
+
+        if query_states.dim() == 4:
+            query_states = query_states.reshape(-1, self.num_heads, self.head_dim)
+            key_states = key_states.reshape(-1, self.num_heads, self.head_dim)
+            value_states = value_states.reshape(-1, self.num_heads, self.head_dim)
+
+        attn_wrapper.set_kv_cache(kv_cache, key_states, value_states)
+        attn_output = attn_wrapper.run(query_states, kv_cache)
+
+        attn_output = attn_output.view(*input_shape, self.hidden_size).contiguous()
+        attn_output = self.out_proj(attn_output)
+
+        return attn_output
+
+class XttsGptBlock(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int, layer_norm_epsilon: int, layer_idx: int):
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
+        self.attn = XttsGptAttention(hidden_size, num_heads)
+        self.ln_2 = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
+        self.mlp = XttsGptMLP(hidden_size, hidden_size * 4)
+        self.layer_idx = layer_idx
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.LongTensor,
+        attn_wrapper: FlashInferWrapper,
+        kv_cache: torch.Tensor,
+    ):
+        residual = hidden_states
+        hidden_states = self.ln_1(hidden_states)
+        
+        # FlashInfer Layer expects kv_cache specifically scoped for this layer_idx
+        layer_kv_cache = kv_cache[self.layer_idx]
+        
+        attn_output = self.attn(
+            hidden_states=hidden_states,
+            position_ids=position_ids,
+            attn_wrapper=attn_wrapper,
+            kv_cache=layer_kv_cache,
+        )
+        
+        hidden_states = residual + attn_output
+
+        residual = hidden_states
+        hidden_states = self.ln_2(hidden_states)
+        feed_forward_hidden_states = self.mlp(hidden_states)
+        
+        hidden_states = residual + feed_forward_hidden_states
+        return hidden_states
+
+
+class XttsGptModel(nn.Module):
+    def __init__(self, num_layers: int, hidden_size: int, num_heads: int, layer_norm_epsilon: int):
+        super().__init__()
+        self.h = nn.ModuleList([
+            XttsGptBlock(hidden_size, num_heads, layer_norm_epsilon, layer_idx=i) #(transformers) hidden_size == embed_dim
+            for i in range(num_layers)
+        ])
+        self.ln_f = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
+
+    # inputs_embeds have to have positional embeddings.
+    # Causal mask is applied inside Block
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.LongTensor,
+        attn_wrapper: FlashInferWrapper,
+        kv_cache: torch.Tensor,
+    ):
+        hidden_states = inputs_embeds
+        
+        for block in self.h:
+            hidden_states = block(
+                hidden_states=hidden_states,
+                position_ids=position_ids,
+                attn_wrapper=attn_wrapper,
+                kv_cache=kv_cache,
+            )
+
+        hidden_states = self.ln_f(hidden_states)
+        return hidden_states
+
+
+class SpeakerManager:
+    def __init__(self, speaker_file_path=None):
+        self.speakers = torch.load(speaker_file_path, weights_only=False)
+
+    @property
+    def name_to_id(self):
+        return self.speakers
+
+    @property
+    def num_speakers(self):
+        return len(self.name_to_id)
+
+    @property
+    def speaker_names(self):
+        return list(self.name_to_id.keys())
+
+
+class LanguageManager:
+    def __init__(self, config):
+        self.langs = config["languages"]
+
+    @property
+    def name_to_id(self):
+        return self.langs
+
+    @property
+    def num_languages(self):
+        return len(self.name_to_id)
+
+    @property
+    def language_names(self):
+        return list(self.name_to_id)
+
+
+
+
+XTTS_OVERLAP_WAV_LEN = 1024  # crossfade window between HiFiGAN chunks
+
+
+@dataclass
+class XTTSDecoderCache(DecoderCache):
+    """Per-request state for streaming HiFiGAN decoding.
+
+    Each chunk runs HiFiGAN on every accumulated latent, slices
+    ``[prev_wav_len - overlap : cur_wav_len - overlap]``, and crossfades with the
+    previous chunk's ``wav_overlap``.
+    """
+
+    speaker_embedding: torch.Tensor = None       # (B, 512, 1)
+    accumulated_latents: torch.Tensor = None     # (B, MAX_MEL, hidden), fp32
+    latent_count: torch.Tensor = None            # (B, 1), int32
+    wav_overlap: torch.Tensor = None             # (B, 1, OVERLAP)
+    has_prev_chunk: torch.Tensor = None          # (B, 1), int32
+    prev_wav_len: torch.Tensor = None            # (B, 1), int32
+
+
+class XTTSModel(BaseLM, nn.Module):
+    def __init__(
+        self,
+        model_name: str,
+        device: str = "cuda",
+        # fp16 is the default: bf16 accumulates audible drift across 30 layers; fp32
+        # is unsupported by FlashInfer attention.
+        dtype: torch.dtype = torch.float16,
+        enable_torch_compile: bool = False,
+        audio_decoder_device: str | None = None,
+        **kwargs
+    ):
+        nn.Module.__init__(self)
+        BaseLM.__init__(self, model_name, device, dtype, enable_torch_compile, audio_decoder_device)
+        self.config = XttsConfig()
+        self.checkpoint_path = self.config.checkpoint_path
+        self.repo_id = self.config.repo_id
+
+        config_path = self._get_cached_or_download_file(self.repo_id, "config.json")
+        vocab_path = self._get_cached_or_download_file(self.repo_id, "vocab.json")
+        model_path = self._get_cached_or_download_file(self.repo_id, "model.pth")
+        speakers_path = self._get_cached_or_download_file(self.repo_id, "speakers_xtts.pth")
+
+        if os.path.exists(config_path):
+            self.config.load_json(config_path)
+
+        self.args = getattr(self.config, "model_args", self.config)
+        if speakers_path and os.path.exists(speakers_path):
+            self.speaker_manager = SpeakerManager(speakers_path)
+        self.language_manager = LanguageManager(self.config)
+
+        self.mel_stats_path = None
+        self.gpt_checkpoint = self.args.gpt_checkpoint
+        self.decoder_checkpoint = self.args.decoder_checkpoint
+        self.gpt_batch_size = self.args.gpt_batch_size
+        if vocab_path and Path(vocab_path).is_file():
+            self.tokenizer = VoiceBpeTokenizer(vocab_file=vocab_path)
+
+        if self.tokenizer.tokenizer is not None:
+            self.args.gpt_number_text_tokens = self.tokenizer.get_number_tokens()
+            self.args.gpt_start_text_token = self.tokenizer.tokenizer.token_to_id("[START]")
+            self.args.gpt_stop_text_token = self.tokenizer.tokenizer.token_to_id("[STOP]")
+        
+        if self.args.gpt_number_text_tokens:
+            # initialize GPT
+            self.start_prompt_token = self.args.gpt_start_audio_token
+            self.stop_prompt_token = self.args.gpt_stop_audio_token
+            self.max_conditioning_inputs = 1
+            self.max_gen_mel_tokens = self.args.gpt_max_audio_tokens - self.max_conditioning_inputs - 2
+            self.max_mel_tokens = -1 if self.args.gpt_max_audio_tokens == -1 else self.args.gpt_max_audio_tokens + 2 + self.max_conditioning_inputs
+            self.max_text_tokens = -1 if self.args.gpt_max_text_tokens == -1 else self.args.gpt_max_text_tokens + 2
+            self.conditioning_encoder = ConditioningEncoder(80, self.args.gpt_n_model_channels, num_attn_heads=self.args.gpt_n_heads)
+            self.conditioning_dropout = nn.Dropout1d(0.1)
+            self.average_conditioning_embeddings = False
+            self.use_perceiver_resampler = self.args.gpt_use_perceiver_resampler
+            self.perceiver_cond_length_compression = 256
+            self.text_embedding = nn.Embedding(self.args.gpt_number_text_tokens, self.args.gpt_n_model_channels)
+            self.mel_embedding = nn.Embedding(self.args.gpt_num_audio_tokens, self.args.gpt_n_model_channels)
+
+            self.gpt = XttsGptModel(
+                num_layers=self.args.gpt_layers,
+                hidden_size=self.args.gpt_n_model_channels,
+                num_heads=self.args.gpt_n_heads,
+                layer_norm_epsilon=self.config.layer_norm_epsilon,
+            )
+
+            self.mel_pos_embedding = LearnedPositionEmbeddings(self.max_mel_tokens, self.args.gpt_n_model_channels)
+            self.text_pos_embedding = LearnedPositionEmbeddings(self.max_text_tokens, self.args.gpt_n_model_channels)
+            self.mel_layer_pos_embedding = None
+            self.text_layer_pos_embedding = None
+            self.mel_solo_embedding = 0
+            self.text_solo_embedding = 0
+            self.final_norm = nn.LayerNorm(self.args.gpt_n_model_channels)
+            self.text_head = nn.Linear(self.args.gpt_n_model_channels, self.args.gpt_number_text_tokens)
+            self.mel_head = nn.Linear(self.args.gpt_n_model_channels, self.args.gpt_num_audio_tokens)
+            self.conditioning_perceiver = PerceiverResampler(dim=self.args.gpt_n_model_channels, depth=2, dim_context=self.args.gpt_n_model_channels, num_latents=32, dim_head=64, heads=8, ff_mult=4, use_flash_attn=False)
+
+        self.hifigan_decoder = HifiDecoder(
+            input_sample_rate=self.args.input_sample_rate,
+            output_sample_rate=self.args.output_sample_rate,
+            output_hop_length=self.args.output_hop_length,
+            ar_mel_length_compression=self.args.gpt_code_stride_len,
+            decoder_input_dim=self.args.decoder_input_dim,
+            d_vector_dim=self.args.d_vector_dim,
+            cond_d_vector_in_each_upsampling_layer=self.args.cond_d_vector_in_each_upsampling_layer,
+        )
+
+        self.register_buffer("mel_stats", torch.ones(80))
+
+        checkpoint = self.get_compatible_checkpoint_state_dict(model_path)
+        checkpoint = self.prepare_checkpoint(checkpoint)
+        self.load_state_dict(checkpoint, strict=True)
+
+        self.hifigan_decoder.eval()
+        self.gpt.eval()
+        self.eval()
+
+        # repetition_window=1 means "accumulate all past tokens in a single slot",
+        # matching HF generate()'s RepetitionPenaltyLogitsProcessor. Small windows
+        # let the model re-emit early tokens and produce garbled audio.
+        self.default_sampling_config = SamplingConfig(
+            top_k=50,
+            top_p=0.85,
+            min_p=None,
+            temperature=0.75,
+            repetition_penalty=10.0,
+            repetition_window=1,
+            cfg_scale=None,
+        )
+
+        # output_audio_length: HiFiGAN expands latents by interp×4 then ×24000/22050
+        # then waveform_decoder ×256.
+        self._detokenize_interval = 20
+        self._detokenize_overlap = 1
+        _stage1 = self._detokenize_interval * (
+            self.args.gpt_code_stride_len // self.args.output_hop_length
+        )
+        _stage2 = int(_stage1 * self.args.output_sample_rate / self.args.input_sample_rate)
+        self._output_audio_length = _stage2 * self.args.output_hop_length
+
+        self._max_accumulated_latents = int(self.args.gpt_max_audio_tokens)
+        self._wav_len_stride = int(self.args.gpt_code_stride_len // self.args.output_hop_length)
+        self._wav_len_osr = int(self.args.output_sample_rate)
+        self._wav_len_isr = int(self.args.input_sample_rate)
+        self._wav_len_hop = int(self.args.output_hop_length)
+
+        # forward() stashes hidden states + row count here for sampling() to read.
+        # Use in-place GPU ops so the values propagate across CUDA-graph replays;
+        # Python attribute assignments only run at capture time.
+        _bridge_rows = 1024
+        self.register_buffer(
+            "_hidden_states_buffer",
+            torch.zeros(_bridge_rows, self.hidden_size, dtype=self.dtype),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_last_n_rows_buffer",
+            torch.zeros(1, dtype=torch.long),
+            persistent=False,
+        )
+
+        self.default_speaker_ref_dict: dict | None = None
+        self.default_speaker_ref_dict_audio_decoder: dict | None = None
+        self._mel_stop_token_id = int(self.args.gpt_stop_audio_token)
+
+        self.to(self.device)
+        for module in (
+            self.gpt,
+            self.text_embedding,
+            self.mel_embedding,
+            self.text_pos_embedding,
+            self.mel_pos_embedding,
+            self.final_norm,
+            self.text_head,
+            self.mel_head,
+            self.conditioning_dropout,
+        ):
+            module.to(self.dtype)
+        # Conditioning encoder/perceiver and HiFiGAN are pinned to fp32: MHA over
+        # the cloning-mel sequence overflows in fp16, and HiFiGAN matches the
+        # reference's vocoder dtype.
+        self.conditioning_encoder.to(torch.float32)
+        self.conditioning_perceiver.to(torch.float32)
+        self.hifigan_decoder.to(self.audio_decoder_device, dtype=torch.float32)
+
+        self._init_default_speaker_ref(speakers_path)
+
+    @property
+    def n_codebooks(self) -> int:
+        return 1
+
+    @property
+    def num_attention_heads(self) -> int:
+        return self.args.gpt_n_heads
+
+    @property
+    def num_key_value_heads(self) -> int:
+        return self.args.gpt_n_heads
+
+    @property
+    def num_hidden_layers(self) -> int:
+        return self.args.gpt_layers
+
+    @property
+    def hidden_size(self) -> int:
+        return self.args.gpt_n_model_channels
+
+    @property
+    def vocab_size(self) -> int:
+        return self.args.gpt_num_audio_tokens
+
+    @property
+    def detokenize_interval(self) -> int:
+        return self._detokenize_interval
+
+    @property
+    def detokenize_overlap(self) -> int:
+        return self._detokenize_overlap
+
+    @property
+    def max_tokens(self) -> int:
+        return self.args.gpt_max_audio_tokens
+
+    @property
+    def n_channels(self) -> int:
+        return 1
+
+    @property
+    def output_audio_length(self) -> int:
+        return self._output_audio_length
+
+    @property
+    def needs_input_features(self) -> bool:
+        return True
+
+    @property
+    def needs_input_masks(self) -> bool:
+        return True
+
+    @property
+    def supports_audio_input(self) -> bool:
+        # Required so the scheduler forwards ``audio_path`` to preprocess
+        # (used here for reference-audio voice cloning).
+        return True
+
+    @property
+    def supports_postprocess_cuda_graph(self) -> bool:
+        # HiFiGAN runs on a variable-length latent slice each chunk, so postprocess
+        # cannot be captured. Prefill/decode still use CUDA graphs.
+        return False
+
+    def is_stop_id(self, token_ids: List[int]) -> bool:
+        return int(token_ids[0]) == self._mel_stop_token_id
+
+    @staticmethod
+    def _load_audio(audiopath, sampling_rate=22050):
+        audio, lsr = torchaudio.load(audiopath)
+        if audio.size(0) != 1:
+            audio = torch.mean(audio, dim=0, keepdim=True)
+        if lsr != sampling_rate:
+            audio = torchaudio.functional.resample(audio, lsr, sampling_rate)
+        audio = audio.clamp(-1, 1)
+        return audio
+
+    def _wav_to_mel_cloning(
+        self,
+        wav: torch.Tensor,
+        *,
+        n_fft: int,
+        hop_length: int,
+        win_length: int,
+        n_mels: int = 80,
+        sample_rate: int = 22050,
+        f_min: int = 0,
+        f_max: int = 8000,
+    ) -> torch.Tensor:
+        mel_stft = torchaudio.transforms.MelSpectrogram(
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            power=2,
+            normalized=False,
+            sample_rate=sample_rate,
+            f_min=f_min,
+            f_max=f_max,
+            n_mels=n_mels,
+            norm="slaney",
+        ).to(wav.device)
+        mel = mel_stft(wav)
+        mel = torch.log(torch.clamp(mel, min=1e-5))
+        mel = mel / self.mel_stats.to(wav.device).unsqueeze(0).unsqueeze(-1)
+        return mel
+
+    @torch.inference_mode()
+    def get_gpt_cond_latents(self, audio: torch.Tensor, sr: int, length: int = 30, chunk_length: int = 6) -> torch.Tensor:
+        MIN_AUDIO_SECONDS = 0.33
+        if sr != 22050:
+            audio = torchaudio.functional.resample(audio, sr, 22050)
+        if length > 0:
+            audio = audio[:, : 22050 * length]
+        # conditioning_encoder + conditioning_perceiver live in fp32 (see __init__)
+        # because their multi-head-attention overflows in fp16. Feed fp32 mel in
+        # and cast the result to the model's dtype at the end so the caller can
+        # concat the cond_latent into the (potentially fp16) GPT prefix.
+        cond_dtype = torch.float32
+        if self.args.gpt_use_perceiver_resampler:
+            style_embs = []
+            for i in range(0, audio.shape[1], 22050 * chunk_length):
+                audio_chunk = audio[:, i : i + 22050 * chunk_length]
+                if audio_chunk.size(-1) < int(22050 * MIN_AUDIO_SECONDS):
+                    continue
+                mel_chunk = self._wav_to_mel_cloning(
+                    audio_chunk, n_fft=2048, hop_length=256, win_length=1024
+                )
+                mel_chunk = mel_chunk.to(device=self.device, dtype=cond_dtype)
+                conds = self.conditioning_encoder(mel_chunk)  # (1, 1024, T) fp32
+                conds = self.conditioning_perceiver(conds.permute(0, 2, 1)).transpose(1, 2)  # (1, 1024, 32) fp32
+                style_embs.append(conds)
+            if not style_embs:
+                raise RuntimeError(
+                    f"Reference audio too short (minimum {MIN_AUDIO_SECONDS:.2f}s)."
+                )
+            cond_latent = torch.stack(style_embs).mean(dim=0)
+        else:
+            mel = self._wav_to_mel_cloning(audio, n_fft=4096, hop_length=1024, win_length=4096)
+            mel = mel.to(device=self.device, dtype=cond_dtype)
+            cond_latent = self.conditioning_encoder(mel)
+        return cond_latent.transpose(1, 2).to(self.dtype)  # (1, 32, 1024) in model dtype
+
+    @torch.inference_mode()
+    def get_speaker_embedding(self, audio: torch.Tensor, sr: int) -> torch.Tensor:
+        audio_16k = torchaudio.functional.resample(audio, sr, 16000)
+        speaker_encoder_device = next(self.hifigan_decoder.speaker_encoder.parameters()).device
+        return (
+            self.hifigan_decoder.speaker_encoder.forward(
+                audio_16k.to(speaker_encoder_device), l2_norm=True
+            )
+            .unsqueeze(-1)
+        )
+
+    @torch.inference_mode()
+    def get_conditioning_latents(
+        self,
+        audio_path,
+        max_ref_length: int = 30,
+        gpt_cond_len: int = 6,
+        gpt_cond_chunk_len: int = 6,
+        load_sr: int = 22050,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        audio_paths = audio_path if isinstance(audio_path, list) else [audio_path]
+        speaker_embeddings = []
+        audios = []
+        for fp in audio_paths:
+            audio = self._load_audio(fp, load_sr)
+            audio = audio[:, : load_sr * max_ref_length].to(self.device)
+            speaker_embeddings.append(self.get_speaker_embedding(audio, load_sr))
+            audios.append(audio)
+        full_audio = torch.cat(audios, dim=-1)
+        gpt_cond_latents = self.get_gpt_cond_latents(
+            full_audio, load_sr, length=gpt_cond_len, chunk_length=gpt_cond_chunk_len
+        )
+        speaker_embedding = torch.stack(speaker_embeddings).mean(dim=0)
+        return gpt_cond_latents, speaker_embedding
+
+    def _init_default_speaker_ref(self, speakers_path: str | None) -> None:
+        """Cache a default conditioning so requests without ``audio_path`` still work.
+
+        Pick by name via ``VOX_XTTS_SPEAKER`` env var; falls back to the first entry.
+        """
+        if not (speakers_path and os.path.exists(speakers_path)):
+            return
+
+        try:
+            speakers = torch.load(speakers_path, map_location="cpu", weights_only=False)
+        except Exception:
+            return
+
+        if not (isinstance(speakers, dict) and speakers):
+            return
+
+        preferred = os.environ.get("VOX_XTTS_SPEAKER")
+        name = preferred if (preferred and preferred in speakers) else next(iter(speakers))
+        entry = speakers[name]
+        if not (isinstance(entry, dict) and "gpt_cond_latent" in entry and "speaker_embedding" in entry):
+            return
+
+        gpt_cond = entry["gpt_cond_latent"]
+        spk = entry["speaker_embedding"]
+        if not torch.is_tensor(gpt_cond):
+            gpt_cond = torch.as_tensor(gpt_cond)
+        if not torch.is_tensor(spk):
+            spk = torch.as_tensor(spk)
+        if gpt_cond.ndim == 2:
+            gpt_cond = gpt_cond.unsqueeze(0)
+        if spk.ndim == 1:
+            spk = spk.view(1, -1, 1)
+        elif spk.ndim == 2:
+            spk = spk.unsqueeze(-1)
+
+        self.default_speaker_ref_dict = {
+            "gpt_cond_latent": gpt_cond.to(self.device, dtype=torch.float32),
+            "speaker_embedding": spk.to(self.device, dtype=torch.float32),
+        }
+        self.default_speaker_ref_dict_audio_decoder = {
+            "gpt_cond_latent": gpt_cond.to(self.audio_decoder_device, dtype=torch.float32),
+            "speaker_embedding": spk.to(self.audio_decoder_device, dtype=torch.float32),
+        }
+
+    def audio_decoder_initial_cache(self, batch_size: int) -> XTTSDecoderCache:
+        """Allocate a fresh per-request decoder cache, broadcasting the default speaker
+        when no reference audio was supplied.
+        """
+        device = self.audio_decoder_device
+        # Default speaker embedding (B, 512, 1); fall back to zeros until Phase 3 runs.
+        if self.default_speaker_ref_dict_audio_decoder is not None:
+            spk = self.default_speaker_ref_dict_audio_decoder["speaker_embedding"]
+            speaker_embedding = spk.expand(batch_size, -1, -1).clone().contiguous()
+        else:
+            speaker_embedding = torch.zeros(
+                batch_size, self.args.d_vector_dim, 1,
+                dtype=torch.float32, device=device,
+            )
+
+        accumulated_latents = torch.zeros(
+            batch_size, self._max_accumulated_latents, self.hidden_size,
+            dtype=torch.float32, device=device,
+        )
+        latent_count = torch.zeros(
+            batch_size, 1, dtype=torch.int32, device=device,
+        )
+        wav_overlap = torch.zeros(
+            batch_size, self.n_channels, XTTS_OVERLAP_WAV_LEN,
+            dtype=torch.float32, device=device,
+        )
+        has_prev_chunk = torch.zeros(
+            batch_size, 1, dtype=torch.int32, device=device,
+        )
+        prev_wav_len = torch.zeros(
+            batch_size, 1, dtype=torch.int32, device=device,
+        )
+        return XTTSDecoderCache(
+            speaker_embedding=speaker_embedding,
+            accumulated_latents=accumulated_latents,
+            latent_count=latent_count,
+            wav_overlap=wav_overlap,
+            has_prev_chunk=has_prev_chunk,
+            prev_wav_len=prev_wav_len,
+        )
+
+    # ------------------------------------------------------------------
+    # Inference: preprocess / forward / sampling / postprocess
+    # ------------------------------------------------------------------
+
+    def _build_prefix_embedding(
+        self,
+        text_token_ids: torch.Tensor,
+        gpt_cond_latent: torch.Tensor,
+    ) -> torch.Tensor:
+        """Match xtts encoder.GPT.compute_embeddings:
+
+            emb = [cond_latents | text_embedding(text) + text_pos_embedding | start_mel + mel_pos[0]]
+        """
+        device = self.device
+
+        # 1. text embedding with learned text-position embedding (cond-relative positions 0..T-1).
+        text_emb = self.text_embedding(text_token_ids) + self.text_pos_embedding(text_token_ids)
+
+        # 2. start_audio_token embedding + mel position 0.
+        start_token = torch.tensor(
+            [[self.args.gpt_start_audio_token]], dtype=torch.long, device=device
+        )
+        start_mel_emb = self.mel_embedding(start_token) + self.mel_pos_embedding(start_token)
+
+        # 3. cond_latents has shape (1, T_cond, hidden_size); no positional embedding.
+        cond_emb = gpt_cond_latent.to(device=device, dtype=text_emb.dtype)
+        if cond_emb.ndim == 2:
+            cond_emb = cond_emb.unsqueeze(0)
+
+        # Final prefix: cond | text(+pos) | start_mel(+pos[0]).
+        prefix = torch.cat([cond_emb, text_emb, start_mel_emb], dim=1)
+        return prefix  # (1, prefix_len, hidden_size)
+
+    @torch.no_grad()
+    def preprocess(
+        self,
+        prompt: str | None = None,
+        audio_path: str | None = None,
+        language: str = "en",
+        **kwargs: Any,
+    ) -> PreprocessOutput:
+        if prompt is None:
+            raise ValueError("XTTS preprocess requires a `prompt` text argument.")
+
+        device = self.device
+
+        # 1. Tokenize text and bracket with [START]/[STOP] (matches XTTS GPT.compute_embeddings).
+        bpe_ids = self.tokenizer.encode(prompt, language)
+        text_ids = (
+            [int(self.args.gpt_start_text_token)]
+            + list(bpe_ids)
+            + [int(self.args.gpt_stop_text_token)]
+        )
+        text_token_ids = torch.tensor([text_ids], dtype=torch.long, device=device)
+
+        # 2. Obtain conditioning latents — per-request audio override, otherwise default speaker.
+        if audio_path is not None:
+            gpt_cond_latent, speaker_embedding = self.get_conditioning_latents(audio_path)
+        else:
+            if self.default_speaker_ref_dict is None:
+                raise RuntimeError(
+                    "No `audio_path` provided and no default speaker is cached. "
+                    "Pass audio_path, or ensure speakers_xtts.pth is downloadable."
+                )
+            gpt_cond_latent = self.default_speaker_ref_dict["gpt_cond_latent"]
+            speaker_embedding = self.default_speaker_ref_dict["speaker_embedding"]
+
+        # 3. Build the prefix in embedding space.
+        prefix_emb = self._build_prefix_embedding(text_token_ids, gpt_cond_latent)
+        prefix_len = prefix_emb.shape[1]
+
+        # 4. Pack vox-serve's PreprocessOutput shape.
+        #    input_tokens shape: (prefix_len, n_codebooks=1) -- values are placeholders for prefix.
+        #    input_masks True everywhere -> forward will use input_features directly.
+        input_tokens = torch.full(
+            (prefix_len, self.n_codebooks),
+            fill_value=int(self.args.gpt_start_audio_token),
+            dtype=torch.int32,
+            device=device,
+        )
+        # input_features: (prefix_len, hidden_size)
+        input_features = prefix_emb.squeeze(0).to(device=device)
+        # input_masks: (prefix_len, n_codebooks) bool, all True for prefix.
+        input_masks = torch.ones(
+            prefix_len, self.n_codebooks, dtype=torch.bool, device=device,
+        )
+
+        # 5. Per-request decoder cache (override default speaker_embedding into it).
+        decoder_cache = self.audio_decoder_initial_cache(batch_size=1)
+        if speaker_embedding is not None:
+            spk = speaker_embedding.to(
+                device=decoder_cache.speaker_embedding.device,
+                dtype=decoder_cache.speaker_embedding.dtype,
+            )
+            if spk.ndim == 2:
+                spk = spk.unsqueeze(-1)
+            decoder_cache.speaker_embedding.copy_(spk)
+
+        # Pre-seed the repetition-penalty cache with token 1 and start_audio_token
+        # so the first-step penalty matches HF's RepetitionPenaltyLogitsProcessor
+        # (it sees the placeholder-filled input_ids = [1, ..., 1, start_audio_token]).
+        repetition_cache = None
+        cfg = self.default_sampling_config
+        if (
+            cfg.repetition_penalty is not None
+            and cfg.repetition_penalty != 1.0
+            and cfg.repetition_window is not None
+        ):
+            repetition_cache = torch.zeros(
+                cfg.repetition_window if cfg.repetition_window > 0 else 1,
+                self.n_codebooks,
+                self.vocab_size,
+                dtype=torch.bool,
+                device=device,
+            )
+            if 1 < self.vocab_size:
+                repetition_cache[:, :, 1] = True
+            start_id = int(self.args.gpt_start_audio_token)
+            if 0 <= start_id < self.vocab_size:
+                repetition_cache[:, :, start_id] = True
+
+        return PreprocessOutput(
+            input_tokens=input_tokens,
+            repetition_cache=repetition_cache,
+            input_masks=input_masks,
+            input_features=input_features,
+            decoder_cache=decoder_cache,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        attn_wrapper: FlashInferWrapper,
+        kv_cache: torch.Tensor,
+        input_features: torch.Tensor | None = None,
+        input_masks: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        # ``input_features`` carries the pre-computed embedding to feed (prefix at
+        # prefill; mel_emb + mel_pos at decode). Use it directly when supplied;
+        # the torch.where fallback introduces fp16 drift that can flip argmax.
+        if input_features is not None:
+            inputs_embeds = input_features
+        else:
+            mel_token_ids = input_ids[:, 0].clamp(0, self.vocab_size - 1)
+            inputs_embeds = self.mel_embedding(mel_token_ids)
+
+        hidden_states = self.gpt(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attn_wrapper=attn_wrapper,
+            kv_cache=kv_cache,
+        )
+        # Second LayerNorm before mel_head; this is the "latent" HiFiGAN consumes.
+        hidden_states = self.final_norm(hidden_states)
+
+        # Stash hidden_states for sampling() via a pre-allocated buffer. Python
+        # attribute assignment runs only at CUDA-graph capture, so use in-place
+        # GPU kernels (.copy_, .fill_) that get re-executed on every replay.
+        n_rows = hidden_states.shape[0]
+        self._hidden_states_buffer[:n_rows].copy_(hidden_states)
+        self._last_n_rows_buffer.fill_(n_rows)
+
+        logits = self.mel_head(hidden_states)
+        return logits[:, None, :]
+
+    def sampling(
+        self,
+        logits: torch.Tensor,
+        requests: List[Request],
+        sampling_params: SamplingConfig | None = None,
+        repetition_cache: torch.Tensor | None = None,
+        cfg_scale: float | None = None,
+        qo_indptr: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> Tuple[torch.Tensor, Coroutine]:
+        cfg = sampling_params or self.default_sampling_config
+
+        if repetition_cache is not None:
+            logits = Sampler.apply_repetition_penalty(
+                logits, repetition_cache, cfg.repetition_penalty
+            )
+
+        output_ids = Sampler.run_sampling(logits.view(-1, self.vocab_size), config=cfg)
+        output_ids = output_ids.view(logits.shape[0], logits.shape[1])
+
+        if repetition_cache is not None:
+            Sampler.update_repetition_penalty_cache(
+                repetition_cache, output_ids, cfg.repetition_window
+            )
+
+        # Recover the per-request final hidden state stashed by forward().
+        # ``qo_indptr`` (cumulative token counts) lets us pick the last row of
+        # each request uniformly across pure-prefill / pure-decode / mixed batches.
+        n_rows = int(self._last_n_rows_buffer.item())
+        h_full = self._hidden_states_buffer[:n_rows]
+        if qo_indptr is not None:
+            last_idx_t = (qo_indptr[1:] - 1).to(h_full.device, dtype=torch.long)
+            last_idx_t = last_idx_t.clamp(max=n_rows - 1)
+            last_h = h_full.index_select(0, last_idx_t).contiguous()
+        elif n_rows == logits.shape[0]:
+            last_h = h_full.contiguous()
+        else:
+            last_idx = []
+            cum = 0
+            for req in requests:
+                seq_len = req.input_length if req.input_length else 1
+                cum += seq_len
+                last_idx.append(min(cum - 1, n_rows - 1))
+            last_idx_t = torch.tensor(last_idx, dtype=torch.long, device=h_full.device)
+            last_h = h_full.index_select(0, last_idx_t).contiguous()
+        device = output_ids.device
+        stop_id = self._mel_stop_token_id
+
+        # Pre-compute the next decode step's input embedding for each request:
+        # next_input = mel_embedding(sampled_id) + mel_pos_embedding(next_step), where
+        # next_step = number of mel tokens generated so far AFTER this append (1-indexed from start_mel pos 0).
+        for i, req in enumerate(requests):
+            sampled = output_ids[i : i + 1, :]  # (1, n_codebooks=1)
+            req.input_tokens = sampled
+
+            next_step = len(req.lm_output_tokens) + 1  # +1 because async append hasn't happened yet
+            sampled_id = sampled[:, 0].clamp(0, self.vocab_size - 1)
+            mel_emb = self.mel_embedding(sampled_id)  # (1, hidden_size)
+            mel_pos = self.mel_pos_embedding.get_fixed_embedding(next_step, device).view(1, -1)
+            next_input = (mel_emb + mel_pos).detach()
+            req.input_features = next_input
+            req.input_masks = torch.ones(1, self.n_codebooks, dtype=torch.bool, device=device)
+
+        async def update_req_states():
+            stop_mask = output_ids[:, 0] == stop_id
+            for i, req in enumerate(requests):
+                req.lm_output_tokens.append(output_ids[i : i + 1])
+
+                # Push a placeholder "audio token" so the worker's chunk-trigger
+                # fires; postprocess reads the actual latents from decoder_cache.
+                req.lm_output_audio_tokens.append(
+                    torch.zeros(1, self.n_codebooks, dtype=torch.int32, device=device)
+                )
+
+                cache = getattr(req, "decoder_cache", None)
+                if cache is not None and cache.accumulated_latents is not None:
+                    pos = int(cache.latent_count[0, 0].item())
+                    max_mel = cache.accumulated_latents.shape[1]
+                    if pos < max_mel:
+                        cache.accumulated_latents[0, pos].copy_(
+                            last_h[i].to(
+                                cache.accumulated_latents.device,
+                                dtype=cache.accumulated_latents.dtype,
+                            ),
+                            non_blocking=True,
+                        )
+                        cache.latent_count[0, 0] = pos + 1
+
+                if bool(stop_mask[i].item()):
+                    req.done_lm_generation = True
+                    req.finish_reason = "stop_id_encountered"
+                if req.next_position_id > self.max_tokens:
+                    req.done_lm_generation = True
+                    req.finish_reason = "max_tokens_reached"
+
+            if repetition_cache is not None:
+                for i, req in enumerate(requests):
+                    req.repetition_cache = repetition_cache[i]
+
+        return output_ids, update_req_states()
+
+    @torch.inference_mode()
+    def postprocess(
+        self,
+        _token_ids: torch.Tensor,
+        decoder_cache: XTTSDecoderCache | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Decode the accumulated GPT latents into one chunk of PCM audio.
+
+        For each row: run HiFiGAN on every latent accumulated so far, slice the
+        new chunk from the right tail, and crossfade with the previous chunk's
+        ``wav_overlap``. Variable-length input precludes CUDA-graph capture.
+        """
+        target_device = self.audio_decoder_device
+        if decoder_cache is None or decoder_cache.accumulated_latents is None:
+            raise RuntimeError(
+                "XTTS postprocess requires decoder_cache with accumulated_latents.",
+            )
+
+        overlap = XTTS_OVERLAP_WAV_LEN
+
+        if (
+            not hasattr(self, "_pp_ramp_in")
+            or self._pp_ramp_in.device != torch.device(target_device)
+        ):
+            self._pp_ramp_in = torch.linspace(
+                0.0, 1.0, overlap, dtype=torch.float32, device=target_device,
+            )
+            self._pp_ramp_out = torch.linspace(
+                1.0, 0.0, overlap, dtype=torch.float32, device=target_device,
+            )
+        ramp_in = self._pp_ramp_in
+        ramp_out = self._pp_ramp_out
+
+        all_acc = decoder_cache.accumulated_latents.to(
+            device=target_device, dtype=torch.float32,
+        )
+        spk_all = decoder_cache.speaker_embedding.to(
+            device=target_device, dtype=torch.float32,
+        )
+
+        B = all_acc.shape[0]
+        per_row_wavs: list[torch.Tensor] = []
+        for i in range(B):
+            n_latents = int(decoder_cache.latent_count[i, 0].item())
+            if n_latents <= 0:
+                per_row_wavs.append(torch.zeros(0, device=target_device))
+                continue
+
+            latents_i = all_acc[i : i + 1, :n_latents, :]
+            spk_i = spk_all[i : i + 1]
+
+            wav_gen = self.hifigan_decoder(latents_i, g=spk_i)
+            if wav_gen.dim() == 3 and wav_gen.shape[0] == 1 and wav_gen.shape[1] == 1:
+                wav_gen = wav_gen.squeeze(0).squeeze(0)
+            elif wav_gen.dim() == 3:
+                wav_gen = wav_gen[0, 0]
+            elif wav_gen.dim() == 2:
+                wav_gen = wav_gen[0] if wav_gen.shape[0] == 1 else wav_gen.reshape(-1)
+
+            cur_wav_len = wav_gen.shape[0]
+            prev_wav_len = int(decoder_cache.prev_wav_len[i, 0].item())
+            has_prev = bool(decoder_cache.has_prev_chunk[i, 0].item())
+
+            if has_prev:
+                start = max(prev_wav_len - overlap, 0)
+                end = max(cur_wav_len - overlap, start)
+                wav_chunk = wav_gen[start:end].clone()
+                if wav_chunk.shape[0] >= overlap:
+                    wo = decoder_cache.wav_overlap[i, 0].to(target_device, dtype=torch.float32)
+                    wav_chunk[:overlap] = wo * ramp_out + wav_chunk[:overlap] * ramp_in
+            else:
+                end = max(cur_wav_len - overlap, 0)
+                wav_chunk = wav_gen[:end].clone()
+
+            if cur_wav_len >= overlap:
+                new_wo = wav_gen[cur_wav_len - overlap : cur_wav_len]
+                decoder_cache.wav_overlap[i, 0].copy_(
+                    new_wo.to(decoder_cache.wav_overlap.dtype)
+                )
+
+            decoder_cache.prev_wav_len[i, 0] = int(cur_wav_len)
+            decoder_cache.has_prev_chunk[i, 0].fill_(1)
+
+            per_row_wavs.append(wav_chunk)
+
+        # batch=1 → T equals the natural chunk length; batch>1 → zero-pad to max(T).
+        T_max = max((w.shape[0] for w in per_row_wavs), default=0)
+        out = torch.zeros(
+            B, self.n_channels, T_max,
+            dtype=torch.float32, device=target_device,
+        )
+        for i, w in enumerate(per_row_wavs):
+            if w.shape[0] > 0:
+                out[i, 0, : w.shape[0]] = w.to(out.dtype)
+
+        return out
+
+    def prepare_checkpoint(self, checkpoint):
+        """Remap original XTTS checkpoint keys onto the XTTSModel architecture."""
+        new_checkpoint = {}
+
+        # Sub-component prefixes that move from gpt.X to X (directly on XTTSModel)
+        gpt_subcomponents = (
+            "gpt.conditioning_encoder.",
+            "gpt.text_embedding.",
+            "gpt.mel_embedding.",
+            "gpt.mel_pos_embedding.",
+            "gpt.text_pos_embedding.",
+            "gpt.final_norm.",
+            "gpt.text_head.",
+            "gpt.mel_head.",
+            "gpt.conditioning_perceiver.",
+            "gpt.conditioning_dropout.",
+        )
+
+        for key, value in checkpoint.items():
+            new_key = key
+
+            # Step 1: Strip 'gpt.' prefix from sub-components
+            for prefix in gpt_subcomponents:
+                if key.startswith(prefix):
+                    new_key = key[len("gpt."):]  # remove 'gpt.' prefix
+                    break
+
+            # Step 2: Collapse 'gpt.gpt.' → 'gpt.' for transformer layers
+            if new_key.startswith("gpt.gpt."):
+                new_key = new_key.replace("gpt.gpt.", "gpt.", 1)
+
+            # Step 3: Split fused c_attn Conv1D → q_proj, k_proj, v_proj Linear
+            if ".attn.c_attn.weight" in new_key:
+                # Conv1D weight shape: (hidden, 3*hidden) → transpose → (3*hidden, hidden) → split
+                base = new_key.replace(".attn.c_attn.weight", "")
+                w = value.T  # (3*hidden, hidden)
+                q_w, k_w, v_w = w.chunk(3, dim=0)
+                new_checkpoint[f"{base}.attn.q_proj.weight"] = q_w.contiguous()
+                new_checkpoint[f"{base}.attn.k_proj.weight"] = k_w.contiguous()
+                new_checkpoint[f"{base}.attn.v_proj.weight"] = v_w.contiguous()
+                continue
+            elif ".attn.c_attn.bias" in new_key:
+                # Bias shape: (3*hidden,) → split
+                base = new_key.replace(".attn.c_attn.bias", "")
+                q_b, k_b, v_b = value.chunk(3, dim=0)
+                new_checkpoint[f"{base}.attn.q_proj.bias"] = q_b
+                new_checkpoint[f"{base}.attn.k_proj.bias"] = k_b
+                new_checkpoint[f"{base}.attn.v_proj.bias"] = v_b
+                continue
+
+            # Step 4: Rename c_proj → out_proj and transpose weight
+            if ".attn.c_proj.weight" in new_key:
+                new_key = new_key.replace(".attn.c_proj.", ".attn.out_proj.")
+                value = value.T.contiguous()  # Conv1D (in, out) → Linear (out, in)
+            elif ".attn.c_proj.bias" in new_key:
+                new_key = new_key.replace(".attn.c_proj.", ".attn.out_proj.")
+
+            # Step 5: Transpose MLP Conv1D weights
+            elif ".mlp.c_fc.weight" in new_key or ".mlp.c_proj.weight" in new_key:
+                value = value.T.contiguous()  # Conv1D (in, out) → Linear (out, in)
+
+            new_checkpoint[new_key] = value
+
+        return new_checkpoint
+    
+    def get_compatible_checkpoint_state_dict(self, model_path: Path) -> dict:
+        checkpoint = self._load_checkpoint(model_path)
+        # remove xtts gpt trainer extra keys
+        ignore_keys = ["torch_mel_spectrogram_style_encoder", "torch_mel_spectrogram_dvae", "dvae"]
+        for key in list(checkpoint.keys()):
+            # check if it is from the coqui Trainer if so convert it
+            if key.startswith("xtts."):
+                new_key = key.replace("xtts.", "")
+                checkpoint[new_key] = checkpoint[key]
+                del checkpoint[key]
+                key = new_key
+
+            # remove unused keys
+            if key.split(".")[0] in ignore_keys:
+                del checkpoint[key]
+
+        return checkpoint
+
+    def _load_checkpoint(self, model_path: Path) -> dict:
+        # XTTS-v2's model.pth references ``TTS.*`` classes from the original
+        # coqui-TTS package; register stub modules so unpickling works without it.
+        self._register_legacy_tts_modules()
+        try:
+            checkpoint = load_fsspec(model_path, map_location=torch.device("cpu"))
+        except (pickle.UnpicklingError, Exception):
+            checkpoint = torch.load(
+                model_path, map_location=torch.device("cpu"), weights_only=False
+            )
+        return checkpoint["model"] if isinstance(checkpoint, dict) and "model" in checkpoint else checkpoint
+
+    @staticmethod
+    def _register_legacy_tts_modules() -> None:
+        """Install a MetaPathFinder that fabricates stub ``TTS.*`` modules on demand."""
+        if getattr(XTTSModel, "_legacy_tts_finder_installed", False):
+            return
+
+        import importlib
+        import importlib.abc
+        import importlib.machinery
+
+        class _StubPlaceholder:
+            def __init__(self, *args, **kwargs):
+                self._stub_args = args
+                self.__dict__.update(kwargs)
+
+            def __setstate__(self, state):
+                if isinstance(state, dict):
+                    self.__dict__.update(state)
+
+        class _StubModule(types.ModuleType):
+            def __getattr__(self, name):
+                # Dunder lookups must raise so torch's frame introspection works.
+                if name.startswith("__") and name.endswith("__"):
+                    raise AttributeError(name)
+                cls = type(name, (_StubPlaceholder,), {"__module__": self.__name__})
+                setattr(self, name, cls)
+                return cls
+
+        class _LegacyTTSLoader(importlib.abc.Loader):
+            def create_module(self, spec):
+                m = _StubModule(spec.name)
+                m.__path__ = []
+                return m
+
+            def exec_module(self, module):
+                pass
+
+        class _LegacyTTSFinder(importlib.abc.MetaPathFinder):
+            _loader = _LegacyTTSLoader()
+
+            def find_spec(self, name, path=None, target=None):
+                if name == "TTS" or name.startswith("TTS."):
+                    spec = importlib.machinery.ModuleSpec(name, self._loader, is_package=True)
+                    spec.submodule_search_locations = []
+                    return spec
+                return None
+
+        sys.meta_path.insert(0, _LegacyTTSFinder())
+
+        # Pre-bind the dataclasses we actually want to use during unpickling.
+        # Forcing the import goes through our finder and yields a _StubModule.
+        cfg_mod = importlib.import_module("TTS.tts.configs.xtts_config")
+        for cls in (XttsConfig, XttsArgs, XttsAudioConfig):
+            setattr(cfg_mod, cls.__name__, cls)
+
+        XTTSModel._legacy_tts_finder_installed = True
+    
+    def _get_cached_or_download_file(self, repo_id: str, filename: str) -> str:
+        """Return a local path for ``filename``, downloading from HF Hub if absent."""
+        local_dir = os.path.expanduser(self.checkpoint_path)
+        local_path = os.path.join(local_dir, filename)
+        if os.path.exists(local_path):
+            return local_path
+        return hf_hub_download(repo_id=repo_id, filename=filename, local_dir=local_dir)
+    

--- a/vox_serve/tokenizer/xtts.py
+++ b/vox_serve/tokenizer/xtts.py
@@ -1,0 +1,686 @@
+import logging
+import os
+import re
+import textwrap
+from functools import cached_property
+from typing import Any
+
+import torch
+from ko_speech_tools import hangul_romanize
+from num2words import num2words
+from tokenizers import Tokenizer
+
+
+logger = logging.getLogger(__name__)
+
+_whitespace_re = re.compile(r"\s+")
+
+
+def collapse_whitespace(text):
+    return re.sub(_whitespace_re, " ", text).strip()
+
+
+def lowercase(text):
+    return text.lower()
+
+
+def get_spacy_lang(lang):
+    try:
+        from spacy.lang.ar import Arabic
+        from spacy.lang.en import English
+        from spacy.lang.es import Spanish
+        from spacy.lang.hi import Hindi
+        from spacy.lang.ja import Japanese
+        from spacy.lang.zh import Chinese
+    except ImportError as e:
+        raise ImportError("enable_text_splitting=True requires Spacy: pip install spacy[ja]") from e
+    """Return Spacy language used for sentence splitting."""
+    if lang == "zh":
+        return Chinese()
+    elif lang == "ja":
+        return Japanese()
+    elif lang == "ar":
+        return Arabic()
+    elif lang == "es":
+        return Spanish()
+    elif lang == "hi":
+        return Hindi()
+    else:
+        # For most languages, English does the job
+        return English()
+
+
+def split_sentence(text, lang, text_split_length=250):
+    """Preprocess the input text"""
+    text_splits = []
+    if text_split_length is not None and len(text) >= text_split_length:
+        text_splits.append("")
+        nlp = get_spacy_lang(lang)
+        nlp.add_pipe("sentencizer")
+        doc = nlp(text)
+        for sentence in doc.sents:
+            if len(text_splits[-1]) + len(str(sentence)) <= text_split_length:
+                # if the last sentence + the current sentence is less than the text_split_length
+                # then add the current sentence to the last sentence
+                text_splits[-1] += " " + str(sentence)
+                text_splits[-1] = text_splits[-1].lstrip()
+            elif len(str(sentence)) > text_split_length:
+                # if the current sentence is greater than the text_split_length
+                for line in textwrap.wrap(
+                    str(sentence),
+                    width=text_split_length,
+                    drop_whitespace=True,
+                    break_on_hyphens=False,
+                    tabsize=1,
+                ):
+                    text_splits.append(str(line))
+            else:
+                text_splits.append(str(sentence))
+
+        if len(text_splits) > 1:
+            if text_splits[0] == "":
+                del text_splits[0]
+    else:
+        text_splits = [text.lstrip()]
+
+    return text_splits
+
+
+# List of (regular expression, replacement) pairs for abbreviations:
+_abbreviations = {
+    "en": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("mrs", "misess"),
+            ("mr", "mister"),
+            ("dr", "doctor"),
+            ("st", "saint"),
+            ("co", "company"),
+            ("jr", "junior"),
+            ("maj", "major"),
+            ("gen", "general"),
+            ("drs", "doctors"),
+            ("rev", "reverend"),
+            ("lt", "lieutenant"),
+            ("hon", "honorable"),
+            ("sgt", "sergeant"),
+            ("capt", "captain"),
+            ("esq", "esquire"),
+            ("ltd", "limited"),
+            ("col", "colonel"),
+            ("ft", "fort"),
+        ]
+    ],
+    "es": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("sra", "señora"),
+            ("sr", "señor"),
+            ("dr", "doctor"),
+            ("dra", "doctora"),
+            ("st", "santo"),
+            ("co", "compañía"),
+            ("jr", "junior"),
+            ("ltd", "limitada"),
+        ]
+    ],
+    "fr": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("mme", "madame"),
+            ("mr", "monsieur"),
+            ("dr", "docteur"),
+            ("st", "saint"),
+            ("co", "compagnie"),
+            ("jr", "junior"),
+            ("ltd", "limitée"),
+        ]
+    ],
+    "de": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("fr", "frau"),
+            ("dr", "doktor"),
+            ("st", "sankt"),
+            ("co", "firma"),
+            ("jr", "junior"),
+        ]
+    ],
+    "pt": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("sra", "senhora"),
+            ("sr", "senhor"),
+            ("dr", "doutor"),
+            ("dra", "doutora"),
+            ("st", "santo"),
+            ("co", "companhia"),
+            ("jr", "júnior"),
+            ("ltd", "limitada"),
+        ]
+    ],
+    "it": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            # ("sig.ra", "signora"),
+            ("sig", "signore"),
+            ("dr", "dottore"),
+            ("st", "santo"),
+            ("co", "compagnia"),
+            ("jr", "junior"),
+            ("ltd", "limitata"),
+        ]
+    ],
+    "pl": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("p", "pani"),
+            ("m", "pan"),
+            ("dr", "doktor"),
+            ("sw", "święty"),
+            ("jr", "junior"),
+        ]
+    ],
+    "ar": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            # There are not many common abbreviations in Arabic as in English.
+        ]
+    ],
+    "zh": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            # Chinese doesn't typically use abbreviations in the same way as Latin-based scripts.
+        ]
+    ],
+    "cs": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("dr", "doktor"),  # doctor
+            ("ing", "inženýr"),  # engineer
+            ("p", "pan"),  # Could also map to pani for woman but no easy way to do it
+            # Other abbreviations would be specialized and not as common.
+        ]
+    ],
+    "ru": [
+        (re.compile(f"\\b{x[0]}\\b", re.IGNORECASE), x[1])
+        for x in [
+            ("г-жа", "госпожа"),  # Mrs.
+            ("г-н", "господин"),  # Mr.
+            ("д-р", "доктор"),  # doctor
+            # Other abbreviations are less common or specialized.
+        ]
+    ],
+    "nl": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("dhr", "de heer"),  # Mr.
+            ("mevr", "mevrouw"),  # Mrs.
+            ("dr", "dokter"),  # doctor
+            ("jhr", "jonkheer"),  # young lord or nobleman
+            # Dutch uses more abbreviations, but these are the most common ones.
+        ]
+    ],
+    "tr": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("b", "bay"),  # Mr.
+            ("byk", "büyük"),  # büyük
+            ("dr", "doktor"),  # doctor
+            # Add other Turkish abbreviations here if needed.
+        ]
+    ],
+    "hu": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            ("dr", "doktor"),  # doctor
+            ("b", "bácsi"),  # Mr.
+            ("nőv", "nővér"),  # nurse
+            # Add other Hungarian abbreviations here if needed.
+        ]
+    ],
+    "ko": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            # Korean doesn't typically use abbreviations in the same way as Latin-based scripts.
+        ]
+    ],
+    "hi": [
+        (re.compile(f"\\b{x[0]}\\.", re.IGNORECASE), x[1])
+        for x in [
+            # Hindi doesn't typically use abbreviations in the same way as Latin-based scripts.
+        ]
+    ],
+}
+
+
+def expand_abbreviations_multilingual(text, lang="en"):
+    for regex, replacement in _abbreviations[lang]:
+        text = re.sub(regex, replacement, text)
+    return text
+
+
+_symbols_multilingual = {
+    "en": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " and "),
+            ("@", " at "),
+            ("%", " percent "),
+            ("#", " hash "),
+            ("$", " dollar "),
+            ("£", " pound "),
+            ("°", " degree "),
+        ]
+    ],
+    "es": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " y "),
+            ("@", " arroba "),
+            ("%", " por ciento "),
+            ("#", " numeral "),
+            ("$", " dolar "),
+            ("£", " libra "),
+            ("°", " grados "),
+        ]
+    ],
+    "fr": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " et "),
+            ("@", " arobase "),
+            ("%", " pour cent "),
+            ("#", " dièse "),
+            ("$", " dollar "),
+            ("£", " livre "),
+            ("°", " degrés "),
+        ]
+    ],
+    "de": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " und "),
+            ("@", " at "),
+            ("%", " prozent "),
+            ("#", " raute "),
+            ("$", " dollar "),
+            ("£", " pfund "),
+            ("°", " grad "),
+        ]
+    ],
+    "pt": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " e "),
+            ("@", " arroba "),
+            ("%", " por cento "),
+            ("#", " cardinal "),
+            ("$", " dólar "),
+            ("£", " libra "),
+            ("°", " graus "),
+        ]
+    ],
+    "it": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " e "),
+            ("@", " chiocciola "),
+            ("%", " per cento "),
+            ("#", " cancelletto "),
+            ("$", " dollaro "),
+            ("£", " sterlina "),
+            ("°", " gradi "),
+        ]
+    ],
+    "pl": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " i "),
+            ("@", " małpa "),
+            ("%", " procent "),
+            ("#", " krzyżyk "),
+            ("$", " dolar "),
+            ("£", " funt "),
+            ("°", " stopnie "),
+        ]
+    ],
+    "ar": [
+        # Arabic
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " و "),
+            ("@", " على "),
+            ("%", " في المئة "),
+            ("#", " رقم "),
+            ("$", " دولار "),
+            ("£", " جنيه "),
+            ("°", " درجة "),
+        ]
+    ],
+    "zh": [
+        # Chinese
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " 和 "),
+            ("@", " 在 "),
+            ("%", " 百分之 "),
+            ("#", " 号 "),
+            ("$", " 美元 "),
+            ("£", " 英镑 "),
+            ("°", " 度 "),
+        ]
+    ],
+    "cs": [
+        # Czech
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " a "),
+            ("@", " na "),
+            ("%", " procento "),
+            ("#", " křížek "),
+            ("$", " dolar "),
+            ("£", " libra "),
+            ("°", " stupně "),
+        ]
+    ],
+    "ru": [
+        # Russian
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " и "),
+            ("@", " собака "),
+            ("%", " процентов "),
+            ("#", " номер "),
+            ("$", " доллар "),
+            ("£", " фунт "),
+            ("°", " градус "),
+        ]
+    ],
+    "nl": [
+        # Dutch
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " en "),
+            ("@", " bij "),
+            ("%", " procent "),
+            ("#", " hekje "),
+            ("$", " dollar "),
+            ("£", " pond "),
+            ("°", " graden "),
+        ]
+    ],
+    "tr": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " ve "),
+            ("@", " at "),
+            ("%", " yüzde "),
+            ("#", " diyez "),
+            ("$", " dolar "),
+            ("£", " sterlin "),
+            ("°", " derece "),
+        ]
+    ],
+    "hu": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " és "),
+            ("@", " kukac "),
+            ("%", " százalék "),
+            ("#", " kettőskereszt "),
+            ("$", " dollár "),
+            ("£", " font "),
+            ("°", " fok "),
+        ]
+    ],
+    "ko": [
+        # Korean
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " 그리고 "),
+            ("@", " 에 "),
+            ("%", " 퍼센트 "),
+            ("#", " 번호 "),
+            ("$", " 달러 "),
+            ("£", " 파운드 "),
+            ("°", " 도 "),
+        ]
+    ],
+    "hi": [
+        (re.compile(rf"{re.escape(x[0])}", re.IGNORECASE), x[1])
+        for x in [
+            ("&", " और "),
+            ("@", " ऐट दी रेट "),
+            ("%", " प्रतिशत "),
+            ("#", " हैश "),
+            ("$", " डॉलर "),
+            ("£", " पाउंड "),
+            ("°", " डिग्री "),
+        ]
+    ],
+}
+
+
+def expand_symbols_multilingual(text, lang="en"):
+    for regex, replacement in _symbols_multilingual[lang]:
+        text = re.sub(regex, replacement, text)
+        text = text.replace("  ", " ")  # Ensure there are no double spaces
+    return text.strip()
+
+
+_ordinal_re = {
+    "en": re.compile(r"([0-9]+)(st|nd|rd|th)"),
+    "es": re.compile(r"([0-9]+)(º|ª|er|o|a|os|as)"),
+    "fr": re.compile(r"([0-9]+)(º|ª|er|re|e|ème)"),
+    "de": re.compile(r"([0-9]+)(st|nd|rd|th|º|ª|\.(?=\s|$))"),
+    "pt": re.compile(r"([0-9]+)(º|ª|o|a|os|as)"),
+    "it": re.compile(r"([0-9]+)(º|°|ª|o|a|i|e)"),
+    "pl": re.compile(r"([0-9]+)(º|ª|st|nd|rd|th)"),
+    "ar": re.compile(r"([0-9]+)(ون|ين|ث|ر|ى)"),
+    "cs": re.compile(r"([0-9]+)\.(?=\s|$)"),  # In Czech, a dot is often used after the number to indicate ordinals.
+    "ru": re.compile(r"([0-9]+)(-й|-я|-е|-ое|-ье|-го)"),
+    "nl": re.compile(r"([0-9]+)(de|ste|e)"),
+    "tr": re.compile(r"([0-9]+)(\.|inci|nci|uncu|üncü|\.)"),
+    "hu": re.compile(r"([0-9]+)(\.|adik|edik|odik|edik|ödik|ödike|ik)"),
+    "ko": re.compile(r"([0-9]+)(번째|번|차|째)"),
+    "hi": re.compile(r"([0-9]+)(st|nd|rd|th)"),  # To check
+}
+_number_re = re.compile(r"[0-9]+")
+_currency_re = {
+    "USD": re.compile(r"((\$[0-9\.\,]*[0-9]+)|([0-9\.\,]*[0-9]+\$))"),
+    "GBP": re.compile(r"((£[0-9\.\,]*[0-9]+)|([0-9\.\,]*[0-9]+£))"),
+    "EUR": re.compile(r"(([0-9\.\,]*[0-9]+€)|((€[0-9\.\,]*[0-9]+)))"),
+}
+
+_comma_number_re = re.compile(r"\b\d{1,3}(,\d{3})*(\.\d+)?\b")
+_dot_number_re = re.compile(r"\b\d{1,3}(.\d{3})*(\,\d+)?\b")
+_decimal_number_re = re.compile(r"([0-9]+[.,][0-9]+)")
+
+
+def _remove_commas(m):
+    text = m.group(0)
+    if "," in text:
+        text = text.replace(",", "")
+    return text
+
+
+def _remove_dots(m):
+    text = m.group(0)
+    if "." in text:
+        text = text.replace(".", "")
+    return text
+
+
+def _expand_decimal_point(m, lang="en"):
+    amount = m.group(1).replace(",", ".")
+    return num2words(float(amount), lang=lang)
+
+
+def _expand_currency(m, lang="en", currency="USD"):
+    amount = float(re.sub(r"[^\d.]", "", m.group(0).replace(",", ".")))
+    full_amount = num2words(amount, to="currency", currency=currency, lang=lang)
+
+    and_equivalents = {
+        "en": ", ",
+        "es": " con ",
+        "fr": " et ",
+        "de": " und ",
+        "pt": " e ",
+        "it": " e ",
+        "pl": ", ",
+        "cs": ", ",
+        "ru": ", ",
+        "nl": ", ",
+        "ar": ", ",
+        "tr": ", ",
+        "hu": ", ",
+        "ko": ", ",
+        "hi": ", ",
+    }
+
+    if amount.is_integer():
+        last_and = full_amount.rfind(and_equivalents[lang])
+        if last_and != -1:
+            full_amount = full_amount[:last_and]
+
+    return full_amount
+
+
+def _expand_ordinal(m, lang="en"):
+    return num2words(int(m.group(1)), ordinal=True, lang=lang)
+
+
+def _expand_number(m, lang="en"):
+    return num2words(int(m.group(0)), lang=lang)
+
+
+def expand_numbers_multilingual(text, lang="en"):
+    if lang == "zh":
+        text = zh_num2words()(text)
+    else:
+        if lang in ["en", "ru"]:
+            text = re.sub(_comma_number_re, _remove_commas, text)
+        else:
+            text = re.sub(_dot_number_re, _remove_dots, text)
+        try:
+            text = re.sub(_currency_re["GBP"], lambda m: _expand_currency(m, lang, "GBP"), text)
+            text = re.sub(_currency_re["USD"], lambda m: _expand_currency(m, lang, "USD"), text)
+            text = re.sub(_currency_re["EUR"], lambda m: _expand_currency(m, lang, "EUR"), text)
+        except:
+            pass
+        if lang != "tr":
+            text = re.sub(_decimal_number_re, lambda m: _expand_decimal_point(m, lang), text)
+        text = re.sub(_ordinal_re[lang], lambda m: _expand_ordinal(m, lang), text)
+        text = re.sub(_number_re, lambda m: _expand_number(m, lang), text)
+    return text
+
+
+def multilingual_cleaners(text, lang):
+    text = text.replace('"', "")
+    if lang == "tr":
+        text = text.replace("İ", "i")
+        text = text.replace("Ö", "ö")
+        text = text.replace("Ü", "ü")
+    text = lowercase(text)
+    text = expand_numbers_multilingual(text, lang)
+    text = expand_abbreviations_multilingual(text, lang)
+    text = expand_symbols_multilingual(text, lang=lang)
+    text = collapse_whitespace(text)
+    return text
+
+
+def chinese_transliterate(text):
+    try:
+        import pypinyin
+    except ImportError as e:
+        raise ImportError("Chinese requires: pypinyin") from e
+    return "".join(
+        [p[0] for p in pypinyin.pinyin(text, style=pypinyin.Style.TONE3, heteronym=False, neutral_tone_with_five=True)]
+    )
+
+
+def japanese_cleaners(text, katsu):
+    text = katsu.romaji(text)
+    text = lowercase(text)
+    return text
+
+
+class VoiceBpeTokenizer:
+    def __init__(self, vocab_file: str | os.PathLike[Any] | None = None):
+        self.tokenizer = None
+        if vocab_file is not None:
+            self.tokenizer = Tokenizer.from_file(str(vocab_file))
+        self.char_limits = {
+            "en": 250,
+            "de": 253,
+            "fr": 273,
+            "es": 239,
+            "it": 213,
+            "pt": 203,
+            "pl": 224,
+            "zh": 82,
+            "ar": 166,
+            "cs": 186,
+            "ru": 182,
+            "nl": 251,
+            "tr": 226,
+            "ja": 71,
+            "hu": 224,
+            "ko": 95,
+            "hi": 150,
+        }
+
+    @cached_property
+    def katsu(self):
+        import cutlet
+
+        return cutlet.Cutlet()
+
+    def check_input_length(self, txt, lang):
+        lang = lang.split("-")[0]  # remove the region
+        limit = self.char_limits.get(lang, 250)
+        if len(txt) > limit:
+            logger.warning(
+                "The text length exceeds the character limit of %d for language '%s', this might cause truncated audio: %s",
+                limit,
+                lang,
+                txt[:50] + "...",
+            )
+
+    def preprocess_text(self, txt, lang):
+        if lang in {"ar", "cs", "de", "en", "es", "fr", "hi", "hu", "it", "nl", "pl", "pt", "ru", "tr", "zh", "ko"}:
+            txt = multilingual_cleaners(txt, lang)
+            if lang == "zh":
+                txt = chinese_transliterate(txt)
+            if lang == "ko":
+                txt = hangul_romanize(txt)
+        elif lang == "ja":
+            txt = japanese_cleaners(txt, self.katsu)
+        else:
+            raise NotImplementedError(f"Language '{lang}' is not supported.")
+        return txt
+
+    def encode(self, txt, lang):
+        lang = lang.split("-")[0]  # remove the region
+        self.check_input_length(txt, lang)
+        txt = self.preprocess_text(txt, lang)
+        lang = "zh-cn" if lang == "zh" else lang
+        txt = f"[{lang}]{txt}"
+        txt = txt.replace(" ", "[SPACE]")
+        return self.tokenizer.encode(txt).ids
+
+    def decode(self, seq):
+        if isinstance(seq, torch.Tensor):
+            seq = seq.cpu().numpy()
+        txt = self.tokenizer.decode(seq, skip_special_tokens=False).replace(" ", "")
+        txt = txt.replace("[SPACE]", " ")
+        txt = txt.replace("[STOP]", "")
+        txt = txt.replace("[UNK]", "")
+        return txt
+
+    def __len__(self):
+        return self.tokenizer.get_vocab_size()
+
+    def get_number_tokens(self):
+        return max(self.tokenizer.get_vocab().values()) + 1


### PR DESCRIPTION
## Summary
Adds Coqui XTTS-v2 support: streaming TTS with reference-audio voice
cloning, CUDA-graph accelerated prefill + decode.

## Dependencies
Depends on PR #49. Without that PR's dtype generalization, XTTS's
fp16 attention crashes the worker.

## Architecture
- GPT-2 backbone (30 layers) with PerceiverResampler conditioning
- HiFiGAN vocoder fed accumulated GPT latents per chunk (variable-length
  input, hence the new postprocess-opt-out from PR #49)
- Multilingual BPE tokenizer with per-language text normalization

## Attribution
- `encoder/xtts.py` and `tokenizer/xtts.py` are adapted from
  [coqui-ai/TTS](https://github.com/coqui-ai/TTS) (MPL-2.0); see
  module headers for upstream provenance.

## New dependencies
- `ko-speech-tools>=0.1.0` (Korean romanization)
- `num2words>=0.5.14` (number expansion for tokenizer)

Closes #41.
